### PR TITLE
fix: readthedocs after deeprank2 renaming

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,7 +15,3 @@ replace = version = {new_version}
 [bumpversion:file:CITATION.cff]
 search = version: "{current_version}"
 replace = version: "{new_version}"
-
-[bumpversion:file:.readthedocs.yaml]
-search = version: "{current_version}"
-replace = version: "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,3 +15,7 @@ replace = version = {new_version}
 [bumpversion:file:CITATION.cff]
 search = version: "{current_version}"
 replace = version: "{new_version}"
+
+[bumpversion:file:.readthedocs.yaml]
+search = version: "{current_version}"
+replace = version: "{new_version}"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-latest"
+  os: "ubuntu-20.04"
   tools:
     python: "3.11"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
+version: "2.0.0"
+
 build:
   os: "ubuntu-latest"
   tools:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+build:
+  os: "ubuntu-latest"
+  tools:
+    python: "3.11"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-version: "2.0.0"
+version: 2
 
 build:
   os: "ubuntu-latest"

--- a/deeprank2/features/contact.py
+++ b/deeprank2/features/contact.py
@@ -4,18 +4,18 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
+from scipy.spatial import distance_matrix
+
+from deeprank2.domain import edgestorage as Efeat
 from deeprank2.molstruct.atom import Atom
 from deeprank2.molstruct.pair import AtomicContact, ResidueContact
 from deeprank2.molstruct.variant import SingleResidueVariant
 from deeprank2.utils.graph import Graph
-from scipy.spatial import distance_matrix
-
-from deeprank2.domain import edgestorage as Efeat
 from deeprank2.utils.parsing import atomic_forcefield
 
 _log = logging.getLogger(__name__)
 
-# for cutoff distances, see: https://github.com/DeepRank/deeprank-core/issues/357#issuecomment-1461813723
+# for cutoff distances, see: https://github.com/DeepRank/deeprank2/issues/357#issuecomment-1461813723
 covalent_cutoff = 2.1
 cutoff_13 = 3.6
 cutoff_14 = 4.2

--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -7,18 +7,18 @@ import h5py
 import numpy as np
 import torch
 import torch.nn.functional as F
+from torch import nn
+from torch_geometric.loader import DataLoader
+from tqdm import tqdm
+
 from deeprank2.dataset import GraphDataset, GridDataset
+from deeprank2.domain import losstypes as losses
+from deeprank2.domain import targetstorage as targets
 from deeprank2.utils.community_pooling import (community_detection,
                                                community_pooling)
 from deeprank2.utils.earlystopping import EarlyStopping
 from deeprank2.utils.exporters import (HDF5OutputExporter, OutputExporter,
                                        OutputExporterCollection)
-from torch import nn
-from torch_geometric.loader import DataLoader
-from tqdm import tqdm
-
-from deeprank2.domain import losstypes as losses
-from deeprank2.domain import targetstorage as targets
 
 _log = logging.getLogger(__name__)
 
@@ -794,7 +794,7 @@ class Trainer():
                 #     [[0,1] if x == [1] else [1,0] for x in target]
                 # ).float()
                 raise ValueError('BCELoss and BCEWithLogitsLoss are currently not supported.\n\t' +
-                                'For further details see: https://github.com/DeepRank/deeprank-core/issues/318')
+                                'For further details see: https://github.com/DeepRank/deeprank2/issues/318')
 
             if isinstance(self.lossfunction, losses.classification_losses) and not isinstance(self.lossfunction, losses.classification_tested):
                 raise ValueError(f'{self.lossfunction} is currently not supported.\n\t' +

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 config = configparser.ConfigParser()
-config.read('setup.cfg')
+config.read('./../setup.cfg')
 CONFIG = {}
 for section in config.sections():
     CONFIG[section] = {}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,9 +20,9 @@
 import os
 import sys
 
-from setuptools.config import setupcfg
+from setuptools.config import read_configuration
 
-CONFIG = setupcfg('./../setup.cfg')
+CONFIG = read_configuration('./../setup.cfg')
 
 
 autodoc_mock_imports = [
@@ -96,7 +96,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'deeprank2'
-author = ''  # TODO: Fill author of documentation
+author = 'Sven van der Burg, Giulia Crocioni, Dani Bodor'
 copyright = f"2022, {author}"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -113,7 +113,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,9 +20,9 @@
 import os
 import sys
 
-from setuptools.config import read_configuration
+from setuptools.config import setupcfg
 
-CONFIG = read_configuration('./../setup.cfg')
+CONFIG = setupcfg('./../setup.cfg')
 
 
 autodoc_mock_imports = [
@@ -80,7 +80,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'recommonmark'
+    'myst_parser'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,17 +13,20 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import configparser
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 import os
 import sys
 
-from setuptools.config import read_configuration
-
-CONFIG = read_configuration('./../setup.cfg')
-
+config = configparser.ConfigParser()
+config.read('setup.cfg')
+CONFIG = {}
+for section in config.sections():
+    CONFIG[section] = {}
+    for option in config.options(section):
+        CONFIG[section][option] = config.get(section, option)
 
 autodoc_mock_imports = [
     'numpy',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,9 @@
-.. DeepRank-GNN documentation master file, created by
-   sphinx-quickstart on Wed May 12 11:56:41 2021.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Deeprank-Core |version| documentation
+DeepRank2 |version| documentation
 ========================================
 
-Deeprank-Core is a deep learning framework for data mining Protein-Protein Interactions (PPIs) using Graph Neural Networks. 
+DeepRank2 is a deep learning framework for data mining Protein-Protein Interactions (PPIs) using Graph Neural Networks. 
 
-Deeprank-Core contains useful APIs for pre-processing PPIs data, computing features and targets, as well as training and testing GNN models.
+DeepRank2 contains useful APIs for pre-processing PPIs data, computing features and targets, as well as training and testing GNN models.
 
 Main features:
 
@@ -34,10 +29,10 @@ Getting started
    getstarted
 
 :doc:`installation`
-    Get Deeprank-Core installed on your computer.
+    Get DeepRank2 installed on your computer.
 
 :doc:`getstarted`
-    Understand how to use Deeprank-Core and how it can help you.
+    Understand how to use DeepRank2 and how it can help you.
 
 Notes
 ===========
@@ -58,10 +53,10 @@ Package reference
    :caption: API
    :hidden:
 
-   reference/deeprank2
+   reference/deeprankcore
 
-:doc:`reference/deeprank2`
-    This section documents the Deeprank-Core API.
+:doc:`reference/deeprankcore`
+    This section documents the DeepRank2 API.
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,9 +53,9 @@ Package reference
    :caption: API
    :hidden:
 
-   reference/deeprankcore
+   reference/deeprank2
 
-:doc:`reference/deeprankcore`
+:doc:`reference/deeprank2`
     This section documents the DeepRank2 API.
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ Before installing deeprank2 you need to install some dependencies. We advise to 
   * if this gives an error, run `sudo apt-get install gcc`.
 * For MacOS with M1 chip (otherwise ignore this): `conda install pytables`
 
-## Deeprank-Core Package
+## DeepRank2 Package
 
 Once the dependencies installed, you can install the latest release of deeprank2 using the PyPi package manager:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx==5.3.0
+sphinx_rtd_theme==1.1.1
+readthedocs-sphinx-search==0.1.1
+myst-parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
 dev =
     yapf
 doc =
-    recommonmark
+    myst-parser
     sphinx
     sphinx_rtd_theme
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ install_requires =
     freesasa == 2.1.0
     tensorboard >= 2.9.0
     protobuf <= 3.20.1
-    myst-parser
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     freesasa == 2.1.0
     tensorboard >= 2.9.0
     protobuf <= 3.20.1
+    myst-parser
 
 [options.extras_require]
 dev =

--- a/tutorials/training_ppi.ipynb
+++ b/tutorials/training_ppi.ipynb
@@ -574,7 +574,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Also in this case, `neuralnet` can be any neural network class that inherits from `torch.nn.Module`, and it shouldn't be specific to regression or classification in terms of output shape. This tutorial uses `CnnClassification` (implemented in `deeprank2.neuralnets.cnn.model3d`). All CNN architectures already implemented in the pakcage can be found [here](https://github.com/DeepRank/deeprank-core/tree/main/deeprank2/neuralnets/cnn) and can be used for training or as a basis for implementing new ones.\n",
+    "- Also in this case, `neuralnet` can be any neural network class that inherits from `torch.nn.Module`, and it shouldn't be specific to regression or classification in terms of output shape. This tutorial uses `CnnClassification` (implemented in `deeprank2.neuralnets.cnn.model3d`). All CNN architectures already implemented in the pakcage can be found [here](https://github.com/DeepRank/deeprank2/tree/main/deeprank2/neuralnets/cnn) and can be used for training or as a basis for implementing new ones.\n",
     "- The rest of the `Trainer` parameters can be used as explained already for graphs."
    ]
   },


### PR DESCRIPTION
This PR fixes readthedocs documentation for the newly named deeprank2 package. In particular:
- as mentioned [here](https://blog.readthedocs.com/migrate-configuration-v2/), readthedocs builds without a configuration file are now deprecated. I added a .readthedocs.yml file to address it. The specific dependencies needed are now specified in docs/requirements.txt, as indicated in the newly added .yml file.
- I updated a .md parser dependency to `myst-parser` as indicated [here](https://github.com/readthedocs/recommonmark), since `recommonmark` won't be maintained anymore and is now deprecated.
- I removed `setuptools.config.read_configuration` from docs/conf.py since it's now deprecated. We're now using `configparser.ConfigParser()`. 
- I fixed the remaining old namings using the new deeprank2 nomenclature. 