### PR TITLE
fix: make scipy 1.11.2 work

### DIFF
--- a/deeprank2/tools/visualization/plotting.py
+++ b/deeprank2/tools/visualization/plotting.py
@@ -9,10 +9,10 @@ import matplotlib.pyplot as plt
 import networkx
 import numpy as np
 import plotly.graph_objs as go
-from deeprank2.tools.visualization.embedding import manifold_embedding
 
 from deeprank2.domain import edgestorage as Efeat
 from deeprank2.domain import nodestorage as Nfeat
+from deeprank2.tools.visualization.embedding import manifold_embedding
 
 _log = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ def plotly_2d( # noqa
     elif method == "mcl":
         matrix = networkx.to_scipy_sparse_matrix(gtmp)
         # run MCL with default parameters
-        result = markov_clustering.run_mcl(matrix)
+        result = markov_clustering.run_mcl(matrix.toarray())
         mcl_clust = markov_clustering.get_clusters(result)  # get clusters
         cluster = {}
         node_key = list(graph.nodes.keys())

--- a/deeprank2/utils/community_pooling.py
+++ b/deeprank2/utils/community_pooling.py
@@ -141,7 +141,8 @@ def community_detection(edge_index, num_nodes: int, edge_attr=None, method: str 
         matrix = nx.to_scipy_sparse_array(g)
 
         # run MCL with default parameters
-        result = mc.run_mcl(matrix)
+
+        result = mc.run_mcl(matrix.toarray())
 
         clusters = mc.get_clusters(result)  # get clusters
 

--- a/deeprank2/utils/community_pooling.py
+++ b/deeprank2/utils/community_pooling.py
@@ -74,7 +74,7 @@ def community_detection_per_batch( # pylint: disable=too-many-locals
         elif method == "mcl":
             matrix = nx.to_scipy_sparse_array(subg)
             # run MCL with default parameters
-            result = mc.run_mcl(matrix)
+            result = mc.run_mcl(matrix.toarray())
             mc_clust = mc.get_clusters(result)  # get clusters
 
             index = np.zeros(subg.number_of_nodes()).astype("int")

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ python_requires = >= 3.9
 install_requires =
     tables >= 3.7
     numpy >= 1.21.5
-    scipy == 1.10.0
+    scipy >= 1.11.2
     h5py >= 3.6.0
     networkx >= 2.6.3
     matplotlib >= 3.5.1


### PR DESCRIPTION
This error is described in #477. Converting the sparse array to a dense array type stops the error from appearing.