### PR TITLE
style: auto-scrape trailing whitespace upon save in VS code

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -64,4 +64,3 @@ runs:
       run: python3 -m pip install .[${{ inputs.extras-require }}]
       env:
         CONDA_PREFIX: /usr/share/miniconda
-        

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: fair-software/howfairis-github-action@0.2.1
         name: Measure compliance with fair-software.eu recommendations
         env:
-          PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
+          PYCHARM_HOSTED: "Trick colorama into displaying colored output"
         with:
           MY_REPO_URL: "https://github.com/${{ github.repository }}"

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -18,7 +18,7 @@ ignore-patterns:
 
 pyroma:
   run: true
-  # pyroma gives errors in the setup.py file, 
+  # pyroma gives errors in the setup.py file,
   # thus we disable here these errors.
   # This should not be happening, because
   # prospector should be ignoring the setup.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,14 @@
     "[python]": {
         "editor.codeActionsOnSave": {
             "source.organizeImports": true
-        }
+        },
+        "files.trimTrailingWhitespace": true,
     },
+
     "python.linting.prospectorEnabled": true,
     "notebook.lineNumbers": "on",
+
+    "[*.yml]": {
+        "files.trimTrailingWhitespace": true,
+    },
 }

--- a/deeprank2/dataset.py
+++ b/deeprank2/dataset.py
@@ -60,7 +60,7 @@ class DeeprankDataset(Dataset):
         self.subset = subset
 
         self.target_filter = target_filter
-        
+
         if check_integrity:
             self._check_hdf5_files()
 
@@ -77,7 +77,7 @@ class DeeprankDataset(Dataset):
 
         # get the device
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        
+
     def _check_hdf5_files(self):
         """Checks if the data contained in the .HDF5 file is valid."""
         _log.info("\nChecking dataset Integrity...")
@@ -99,7 +99,7 @@ class DeeprankDataset(Dataset):
 
     def _check_task_and_classes(self, task: str, classes: Optional[str] = None):
 
-        if self.target in [targets.IRMSD, targets.LRMSD, targets.FNAT, targets.DOCKQ]: 
+        if self.target in [targets.IRMSD, targets.LRMSD, targets.FNAT, targets.DOCKQ]:
             self.task = targets.REGRESS
 
         elif self.target in [targets.BINARY, targets.CAPRI]:
@@ -129,19 +129,19 @@ class DeeprankDataset(Dataset):
         else:
             self.classes = None
             self.classes_to_index = None
-            
+
     def _check_inherited_params(
         self,
         inherited_params: List[str],
         dataset_train: Union[GraphDataset, GridDataset],
     ):
         """"Check if the parameters for validation and/or testing are the same as in the training set.
-        
+
         Args:
         inherited_params (List[str]): List of parameters that need to be checked for inheritance.
         dataset_train (Union[class:`GraphDataset`, class:`GridDataset`]): The parameters in `inherited_param` will be inherited from `dataset_train`.
         """
-        
+
         self_vars = vars(self)
         dataset_train_vars = vars(dataset_train)
 
@@ -162,7 +162,7 @@ class DeeprankDataset(Dataset):
         _log.debug(f"Processing data set with .HDF5 files: {self.hdf5_paths}")
 
         self.index_entries = []
-        
+
         desc = f"   {self.hdf5_paths}{' dataset':25s}"
         if self.use_tqdm:
             hdf5_path_iterator = tqdm(self.hdf5_paths, desc=desc, file=sys.stdout)
@@ -180,14 +180,14 @@ class DeeprankDataset(Dataset):
                         entry_names = list(hdf5_file.keys())
                     else:
                         entry_names = [entry_name for entry_name in self.subset if entry_name in list(hdf5_file.keys())]
-                    
+
                     #skip self._filter_targets when target_filter is None, improve performance using list comprehension.
                     if self.target_filter is None:
                         self.index_entries += [(hdf5_path, entry_name) for entry_name in entry_names]
                     else:
                         self.index_entries += [(hdf5_path, entry_name) for entry_name in entry_names \
                         if self._filter_targets(hdf5_file[entry_name])]
-                        
+
             except Exception:
                 _log.exception(f"on {hdf5_path}")
 
@@ -249,7 +249,7 @@ class DeeprankDataset(Dataset):
 
         Returns:
             :class:`pd.DataFrame`: Pandas DataFrame containing the selected features as columns per all data points in
-                hdf5_path files.   
+                hdf5_path files.
         """
 
         df_final = pd.DataFrame()
@@ -258,7 +258,7 @@ class DeeprankDataset(Dataset):
             with h5py.File(fname, 'r') as f:
 
                 entry_name = list(f.keys())[0]
-                
+
                 if self.subset is not None:
                     entry_names = [entry for entry, _ in f.items() if entry in self.subset]
                 else:
@@ -275,7 +275,7 @@ class DeeprankDataset(Dataset):
                             transform = self.features_transform.get('all', {}).get('transform')
                             if (transform is None) and (feat in self.features_transform):
                                 transform = self.features_transform.get(feat, {}).get('transform')
-                        #Check the number of channels the features have    
+                        #Check the number of channels the features have
                         if f[entry_name][feat_type][feat][()].ndim == 2:
                             for i in range(f[entry_name][feat_type][feat][:].shape[1]):
                                 df_dict[feat + '_' + str(i)] = [f[entry_name][feat_type][feat][:][:,i] for entry_name in entry_names]
@@ -290,7 +290,7 @@ class DeeprankDataset(Dataset):
                             #apply transformation
                             if transform:
                                 df_dict[feat]=[transform(row) for row in df_dict[feat]]
-        
+
                 df = pd.DataFrame(data=df_dict)
 
             df_final = pd.concat([df_final, df])
@@ -311,7 +311,7 @@ class DeeprankDataset(Dataset):
         """After having generated a pd.DataFrame using hdf5_to_pandas method, histograms of the features can be saved in an image.
 
         Args:
-            features (Union[str, List[str]]): Features to be plotted. 
+            features (Union[str, List[str]]): Features to be plotted.
             fname (str): str or path-like or binary file-like object.
                 Defaults to 'features_hist.png'.
             bins (Union[int, List[float], str, optional]): If bins is an integer, it defines the number of equal-width bins in the range.
@@ -325,12 +325,12 @@ class DeeprankDataset(Dataset):
         """
         if self.df is None:
             self.hdf5_to_pandas()
-        
+
         if not isinstance(features, list):
             features = [features]
 
         features_df = [col for feat in features for col in self.df.columns.values.tolist() if feat in col]
-        
+
         means = [
             round(np.concatenate(self.df[feat].values).mean(), 1) if isinstance(self.df[feat].values[0], np.ndarray) \
             else round(self.df[feat].values.mean(), 1) \
@@ -344,7 +344,7 @@ class DeeprankDataset(Dataset):
 
             fig, axs = plt.subplots(len(features_df), figsize=figsize)
 
-            for row, feat in enumerate(features_df):       
+            for row, feat in enumerate(features_df):
                 if isinstance(self.df[feat].values[0], np.ndarray):
                     if(log):
                         log_data = np.log(np.concatenate(self.df[feat].values))
@@ -355,7 +355,7 @@ class DeeprankDataset(Dataset):
                 else:
                     if(log):
                         log_data = np.log(self.df[feat].values)
-                        log_data[log_data == -np.inf] = 0 
+                        log_data[log_data == -np.inf] = 0
                         axs[row].hist(log_data, bins=bins)
                     else:
                         axs[row].hist(self.df[feat].values, bins=bins)
@@ -383,13 +383,13 @@ class DeeprankDataset(Dataset):
 
         else:
             raise ValueError("Please provide valid features names. They must be present in the current :class:`DeeprankDataset` children instance.")
-        
+
         fig.tight_layout()
         fig.savefig(fname)
         plt.close(fig)
-    
+
     def _compute_mean_std(self):
-               
+
         means = {col: round(np.nanmean(np.concatenate(self.df[col].values)), 1) if isinstance(self.df[col].values[0], np.ndarray) \
             else round(np.nanmean(self.df[col].values), 1) \
             for col in self.df.columns[1:]}
@@ -399,7 +399,7 @@ class DeeprankDataset(Dataset):
         self.means = means
         self.devs = devs
 
-                        
+
 # Grid features are stored per dimension and named accordingly.
 # Example: position_001, position_002, position_003 (for x,y,z)
 # Use this regular expression to take the feature name apart
@@ -431,26 +431,26 @@ class GridDataset(DeeprankDataset):
             train (bool, optional): Boolean flag to determine if the instance represents the training set.
                 If False, a dataset_train of the same class must be provided as well.
                 The latter will be used to scale the validation/testing set according to its features values and to match the datasets' parameters.
-                Defaults to True.    
+                Defaults to True.
             dataset_train (class:`GridDataset`, optional): If `train` is True, assign here the training set.
                 If `train` is False and `dataset_train` is assigned,
-                the parameters `features`, `target`, `traget_transform`, `task`, and `classes` will be inherited from `dataset_train`. 
+                the parameters `features`, `target`, `traget_transform`, `task`, and `classes` will be inherited from `dataset_train`.
                 Defaults to None.
             features (Optional[Union[List[str], str]], optional): Consider all pre-computed features ("all") or some defined node features
                 (provide a list, example: ["res_type", "polarity", "bsa"]). The complete list can be found in `deeprank2.domain.gridstorage`.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
-                Defaults to "all". 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
+                Defaults to "all".
             target (Optional[str], optional): Default options are irmsd, lrmsd, fnat, binary, capri_class, and dockq. It can also be
-                a custom-defined target given to the Query class as input (see: `deeprank2.query`); in this case, 
+                a custom-defined target given to the Query class as input (see: `deeprank2.query`); in this case,
                 the task parameter needs to be explicitly specified as well.
                 Only numerical target variables are supported, not categorical.
                 If the latter is your case, please convert the categorical classes into
                 numerical class indices before defining the :class:`GraphDataset` instance.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to None.
             target_transform (Optional[bool], optional): Apply a log and then a sigmoid transformation to the target (for regression only).
                 This puts the target value between 0 and 1, and can result in a more uniform target distribution and speed up the optimization.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to False.
             target_filter (Optional[Dict[str, str]], optional): Dictionary of type [target: cond] to filter the molecules.
                 Note that the you can filter on a different target than the one selected as the dataset target.
@@ -459,10 +459,10 @@ class GridDataset(DeeprankDataset):
                 ['irmsd', 'lrmsd', 'fnat', 'binary', 'capri_class', or 'dockq'], otherwise this setting is ignored.
                 Automatically set to 'classif' if the target is 'binary' or 'capri_classes'.
                 Automatically set to 'regress' if the target is 'irmsd', 'lrmsd', 'fnat', or 'dockq'.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to None.
             classes (Optional[Union[List[str], List[int], List[float]], optional]): Define the dataset target classes in classification mode.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to None.
             tqdm (Optional[bool], optional): Show progress bar.
                 Defaults to True.
@@ -488,11 +488,11 @@ class GridDataset(DeeprankDataset):
             if not isinstance(dataset_train, GridDataset):
                 raise TypeError(f"""The train dataset provided is type: {type(dataset_train)}
                                 Please provide a valid training GridDataset.""")
-            
+
             #check inherited parameter with the ones in the training set
             inherited_params = ["features", "target", "target_transform", "task", "classes"]
             self._check_inherited_params(inherited_params, dataset_train)
-            
+
         elif train and dataset_train:
             _log.warning("""dataset_train has been set but train flag was set to True.
             dataset_train will be ignored since the current dataset will be considered as training set.""")
@@ -589,7 +589,7 @@ class GridDataset(DeeprankDataset):
         Args:
             hdf5_path (str): .HDF5 file name.
             entry_name (str): Name of the entry.
-            
+
         Returns:
             :class:`torch_geometric.data.data.Data`: item with tensors x, y if present, entry_names.
         """
@@ -602,7 +602,7 @@ class GridDataset(DeeprankDataset):
 
             mapped_features_group = entry_group[gridstorage.MAPPED_FEATURES]
             for feature_name in self.features:
-                if feature_name[0] != '_':  # ignore metafeatures     
+                if feature_name[0] != '_':  # ignore metafeatures
                     feature_data.append(mapped_features_group[feature_name][:])
 
             target_value = entry_group[targets.VALUES][self.target][()]
@@ -641,16 +641,16 @@ class GraphDataset(DeeprankDataset):
         Args:
             hdf5_path (Union[str, List[str]]): Path to .HDF5 file(s). For multiple .HDF5 files, insert the paths in a List.
                 Defaults to None.
-            subset (Optional[List[str]], optional): List of keys from .HDF5 file to include. 
+            subset (Optional[List[str]], optional): List of keys from .HDF5 file to include.
                 Defaults to None (meaning include all).
             train (bool, optional): Boolean flag to determine if the instance represents the training set.
                 If False, a dataset_train of the same class must be provided as well.
                 The latter will be used to scale the validation/testing set according to its features values and to match the datasets' parameters.
-                Defaults to True.    
+                Defaults to True.
             dataset_train (class:`GraphDataset`, optional): If `train` is True, assign here the training set.
                 If `train` is False and `dataset_train` is assigned,
                 the parameters `node_features`, `edge_features`, `features_transform`, `target`,
-                `target_transform`, `task` and `classes` will be inherited from `dataset_train`. 
+                `target_transform`, `task` and `classes` will be inherited from `dataset_train`.
                 Defaults to None.
             node_features (Optional[Union[List[str], str], optional): Consider all pre-computed node features ("all") or
                 some defined node features (provide a list, example: ["res_type", "polarity", "bsa"]).
@@ -660,7 +660,7 @@ class GraphDataset(DeeprankDataset):
             edge_features (Optional[Union[List[str], str], optional): Consider all pre-computed edge features ("all") or
                 some defined edge features (provide a list, example: ["dist", "coulomb"]).
                 The complete list can be found in `deeprank2.domain.edgestorage`.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to "all".
             features_transform (Optional[dict], optional): Dictionary to indicate the transformations to apply to each feature in the dictionary, being the
                 transformations lambda functions and/or standardization.
@@ -680,16 +680,16 @@ class GraphDataset(DeeprankDataset):
                 :class:`Datasets` belong to the "cluster" Group. They are saved in the .HDF5 file to make them available to networks
                 that make use of clustering methods. Defaults to None.
             target (Optional[str], optional): Default options are irmsd, lrmsd, fnat, binary, capri_class, and dockq.
-                It can also be a custom-defined target given to the Query class as input (see: `deeprank2.query`); 
+                It can also be a custom-defined target given to the Query class as input (see: `deeprank2.query`);
                 in this case, the task parameter needs to be explicitly specified as well.
-                Only numerical target variables are supported, not categorical. 
+                Only numerical target variables are supported, not categorical.
                 If the latter is your case, please convert the categorical classes into
                 numerical class indices before defining the :class:`GraphDataset` instance.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to None.
             target_transform (Optional[bool], optional): Apply a log and then a sigmoid transformation to the target (for regression only).
                 This puts the target value between 0 and 1, and can result in a more uniform target distribution and speed up the optimization.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to False.
             target_filter (Optional[Dict[str, str]], optional): Dictionary of type [target: cond] to filter the molecules.
                 Note that the you can filter on a different target than the one selected as the dataset target.
@@ -698,15 +698,15 @@ class GraphDataset(DeeprankDataset):
                 ['irmsd', 'lrmsd', 'fnat', 'binary', 'capri_class', or 'dockq'], otherwise this setting is ignored.
                 Automatically set to 'classif' if the target is 'binary' or 'capri_classes'.
                 Automatically set to 'regress' if the target is 'irmsd', 'lrmsd', 'fnat', or 'dockq'.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to None.
             classes (Optional[Union[List[str], List[int], List[float]]], optional): Define the dataset target classes in classification mode.
-                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned. 
+                Value will be ignored and inherited from `dataset_train` if `train` is set as False and `dataset_train` is assigned.
                 Defaults to None.
             tqdm (Optional[bool], optional): Show progress bar. Defaults to True.
             root (Optional[str], optional): Root directory where the dataset should be saved. Defaults to "./".
             check_integrity (bool, optional): Whether to check the integrity of the hdf5 files.
-                Defaults to True.     
+                Defaults to True.
         """
 
         super().__init__(hdf5_path, subset, target, task, classes, tqdm, root, target_filter, check_integrity)
@@ -729,11 +729,11 @@ class GraphDataset(DeeprankDataset):
             if not isinstance(dataset_train, GraphDataset):
                 raise TypeError(f"""The train dataset provided is type: {type(dataset_train)}
                                 Please provide a valid training GraphDataset.""")
-            
+
             #check inherited parameter with the ones in the training set
             inherited_params = ["node_features", "edge_features", "features_transform", "target", "target_transform", "task", "classes"]
             self._check_inherited_params(inherited_params, dataset_train)
-            
+
         elif train and dataset_train:
             _log.warning("""dataset_train has been set but train flag was set to True.
             dataset_train will be ignored since the current dataset will be considered as training set.""")
@@ -751,7 +751,7 @@ class GraphDataset(DeeprankDataset):
         if self.features_transform:
             standardize = any(self.features_transform[key].get("standardize") for key, _ in self.features_transform.items())
 
-        if standardize and train: 
+        if standardize and train:
             if self.means or self.devs is None:
                 if self.df is None:
                     self.hdf5_to_pandas()
@@ -762,8 +762,8 @@ class GraphDataset(DeeprankDataset):
                     dataset_train.hdf5_to_pandas()
                 dataset_train._compute_mean_std()
             self.means = dataset_train.means
-            self.devs = dataset_train.devs   
-        
+            self.devs = dataset_train.devs
+
     def get(self, idx: int) -> Data:
         """Gets one graph item from its unique index.
 
@@ -776,18 +776,18 @@ class GraphDataset(DeeprankDataset):
 
         fname, mol = self.index_entries[idx]
         return self.load_one_graph(fname, mol)
-    
+
     def load_one_graph(self, fname: str, entry_name: str)  -> Data: # pylint: disable = too-many-locals # noqa: MC0001
         """Loads one graph.
 
         Args:
             fname (str): .HDF5 file name.
             entry_name (str): Name of the entry.
-            
+
         Returns:
             :class:`torch_geometric.data.data.Data`: item with tensors x, y if present, edge_index, edge_attr, pos, entry_names.
         """
-       
+
         with h5py.File(fname, 'r') as f5:
             grp = f5[entry_name]
 
@@ -795,7 +795,7 @@ class GraphDataset(DeeprankDataset):
             if len(self.node_features) > 0:
                 node_data = ()
                 for feat in self.node_features:
-                    
+
                     # resetting transformation and standardization for each feature
                     transform = None
                     standard = None
@@ -823,10 +823,10 @@ class GraphDataset(DeeprankDataset):
                                                      f"Please change the transformation function for {feat}.")
 
                         if vals.ndim == 1: # features with only one channel
-                            vals = vals.reshape(-1, 1)   
+                            vals = vals.reshape(-1, 1)
                             if standard:
                                 vals = (vals-self.means[feat])/self.devs[feat]
-                        else:       
+                        else:
                             if standard:
                                 reshaped_mean = [mean_value for mean_key, mean_value in self.means.items() if feat in mean_key]
                                 reshaped_dev = [dev_value for dev_key, dev_value in self.devs.items() if feat in dev_key]
@@ -856,7 +856,7 @@ class GraphDataset(DeeprankDataset):
                     # resetting transformation and standardization for each feature
                     transform = None
                     standard = None
-                        
+
                     if feat[0] != '_':   # ignore metafeatures
                         vals = grp[f"{Efeat.EDGE}/{feat}"][()]
                         # get feat transformation and standardization
@@ -869,7 +869,7 @@ class GraphDataset(DeeprankDataset):
                             # if no standardization is set for all features, check if one is set for the current feature
                             if (standard is None) and (feat in self.features_transform):
                                 standard = self.features_transform.get(feat, {}).get('standardize')
-                                
+
                         # apply transformation
                         if transform:
                             with warnings.catch_warnings(record=True) as w:
@@ -878,12 +878,12 @@ class GraphDataset(DeeprankDataset):
                                     raise ValueError(f"Invalid value occurs in {entry_name}, file {fname},"
                                                      f"when applying {transform} for feature {feat}."
                                                      f"Please change the transformation function for {feat}.")
-                                
+
                         if vals.ndim == 1:
                             vals = vals.reshape(-1, 1)
-                            if standard: 
+                            if standard:
                                 vals = (vals-self.means[feat])/self.devs[feat]
-                        else:                                
+                        else:
                             if standard:
                                 reshaped_mean = [mean_value for mean_key, mean_value in self.means.items() if feat in mean_key]
                                 reshaped_dev = [dev_value for dev_key, dev_value in self.devs.items() if feat in dev_key]
@@ -1025,7 +1025,7 @@ def save_hdf5_keys(
         src_ids (List[str]): Keys to be saved in the new .HDF5 file. It should be a list containing at least one key.
         f_dest_path (str): The path to the new .HDF5 file.
         hardcopy (bool, optional): If False, the new file contains only references (external links, see :class:`ExternalLink` class from `h5py`)
-            to the original .HDF5 file. 
+            to the original .HDF5 file.
             If True, the new file contains a copy of the objects specified in src_ids (see h5py :class:`HardLink` from `h5py`).
             Defaults to False.
     """

--- a/deeprank2/domain/aminoacidlist.py
+++ b/deeprank2/domain/aminoacidlist.py
@@ -4,7 +4,7 @@ from deeprank2.molstruct.aminoacid import AminoAcid, Polarity
 
 # All info below sourced from above websites in December 2022 and summarized in deeprank2/domain/aminoacid_summary.xlsx
 
-# Charge is calculated from summing all atoms in the residue (from ./deeprank2/domain/forcefield/protein-allhdg5-5_new.top). 
+# Charge is calculated from summing all atoms in the residue (from ./deeprank2/domain/forcefield/protein-allhdg5-5_new.top).
 # This results in the expected charge of 0 for all POLAR and NONPOLAR residues, +1 for POSITIVE residues and -1 for NEGATIVE residues.
 # Note that SER, THR, and TYR lead to a charge of ~1e-16. A rounding error is assumed in these cases and they are set to 0.
 
@@ -19,7 +19,7 @@ from deeprank2.molstruct.aminoacid import AminoAcid, Polarity
 # The other sources have some minor discrepancies compared to this and are commented inline.
 
 # Source for size:
-#   https://www.shimadzu.co.jp/aboutus/ms_r/archive/files/AminoAcidTable.pdf 
+#   https://www.shimadzu.co.jp/aboutus/ms_r/archive/files/AminoAcidTable.pdf
 
 # Sources for mass and pI:
 #   1) https://www.sigmaaldrich.com/NL/en/technical-documents/technical-article/protein-biology/protein-structural-analysis/amino-acid-reference-chart
@@ -69,7 +69,7 @@ selenocysteine = AminoAcid(
     "U",
     charge = 0,
     polarity = Polarity.POLAR, # source 3: "special case"
-    size = 2, # source: https://en.wikipedia.org/wiki/Selenocysteine 
+    size = 2, # source: https://en.wikipedia.org/wiki/Selenocysteine
     mass = 150.0, # only from source 3
     pI = 5.47, # only from source 3
     hydrogen_bond_donors = 1, # unconfirmed
@@ -174,7 +174,7 @@ pyrrolysine = AminoAcid(
     "PYL",
     "O",
     charge = 0, # unconfirmed
-    polarity = Polarity.POLAR, # based on having both H-bond donors and acceptors 
+    polarity = Polarity.POLAR, # based on having both H-bond donors and acceptors
     size = 13, # source: https://en.wikipedia.org/wiki/Pyrrolysine
     mass = 255.32, # from source 3
     pI = 7.394, # rough estimate from https://rstudio-pubs-static.s3.amazonaws.com/846259_7a9236df54e6410a972621590ecdcfcb.html
@@ -353,9 +353,9 @@ amino_acids = [
     ]
 
 def convert_aa_nomenclature(aa: str, output_type: Optional[int] = None):
-    
+
     # pylint: disable = raise-missing-from
-    try: 
+    try:
         if len(aa) == 1:
             aa: AminoAcid = [entry for entry in amino_acids if entry.one_letter_code.lower() == aa.lower()][0]
         elif len(aa) == 3:
@@ -367,7 +367,7 @@ def convert_aa_nomenclature(aa: str, output_type: Optional[int] = None):
 
     if not output_type:
         return aa.name
-    if output_type == 3: 
+    if output_type == 3:
         return aa.three_letter_code
     if output_type == 1:
         return aa.one_letter_code

--- a/deeprank2/domain/losstypes.py
+++ b/deeprank2/domain/losstypes.py
@@ -1,31 +1,31 @@
 from torch import nn
 
-regression_losses = (nn.L1Loss, 
-                    nn.SmoothL1Loss, 
-                    nn.MSELoss, 
+regression_losses = (nn.L1Loss,
+                    nn.SmoothL1Loss,
+                    nn.MSELoss,
                     nn.HuberLoss)
 
-binary_classification_losses = (nn.SoftMarginLoss, 
-                                nn.BCELoss, 
+binary_classification_losses = (nn.SoftMarginLoss,
+                                nn.BCELoss,
                                 nn.BCEWithLogitsLoss)
 
-multi_classification_losses = (nn.CrossEntropyLoss, 
-                                nn.NLLLoss, 
-                                nn.PoissonNLLLoss, 
-                                nn.GaussianNLLLoss, 
-                                nn.KLDivLoss, 
-                                nn.MultiLabelMarginLoss, 
+multi_classification_losses = (nn.CrossEntropyLoss,
+                                nn.NLLLoss,
+                                nn.PoissonNLLLoss,
+                                nn.GaussianNLLLoss,
+                                nn.KLDivLoss,
+                                nn.MultiLabelMarginLoss,
                                 nn.MultiLabelSoftMarginLoss)
 
-other_losses = (nn.HingeEmbeddingLoss, 
-                nn.CosineEmbeddingLoss, 
-                nn.MarginRankingLoss, 
-                nn.TripletMarginLoss, 
+other_losses = (nn.HingeEmbeddingLoss,
+                nn.CosineEmbeddingLoss,
+                nn.MarginRankingLoss,
+                nn.TripletMarginLoss,
                 nn.CTCLoss)
-                
+
 classification_losses = multi_classification_losses + binary_classification_losses
 
-classification_tested = (nn.CrossEntropyLoss, 
-                        nn.NLLLoss, 
-                        nn.BCELoss, 
+classification_tested = (nn.CrossEntropyLoss,
+                        nn.NLLLoss,
+                        nn.BCELoss,
                         nn.BCEWithLogitsLoss)

--- a/deeprank2/domain/nodestorage.py
+++ b/deeprank2/domain/nodestorage.py
@@ -13,7 +13,7 @@ PDBOCCUPANCY = "pdb_occupancy"
 
 ## residue core features
 RESTYPE = "res_type" # AminoAcid object; former FEATURENAME_AMINOACID
-RESCHARGE = "res_charge" # float(<0); former FEATURENAME_CHARGE (was not assigned) 
+RESCHARGE = "res_charge" # float(<0); former FEATURENAME_CHARGE (was not assigned)
 POLARITY = "polarity" #  Polarity object; former FEATURENAME_POLARITY
 RESSIZE = "res_size" # int; former FEATURENAME_SIZE
 RESMASS = "res_mass"
@@ -39,7 +39,7 @@ DIFFCONSERVATION = "diff_conservation" # int; former FEATURENAME_PSSMDIFFERENCE 
 
 ## protein context features
 RESDEPTH = "res_depth" # float; former FEATURENAME_RESIDUEDEPTH
-HSE = "hse" # list[3xfloat]; former FEATURENAME_HALFSPHEREEXPOSURE 
+HSE = "hse" # list[3xfloat]; former FEATURENAME_HALFSPHEREEXPOSURE
 SASA = "sasa" # float; former FEATURENAME_SASA
 BSA = "bsa" # float; former FEATURENAME_BURIEDSURFACEAREA
 SECSTRUCT = "sec_struct" #secondary structure

--- a/deeprank2/features/components.py
+++ b/deeprank2/features/components.py
@@ -23,12 +23,12 @@ def add_features( # pylint: disable=unused-argument
         elif isinstance(node.id, Atom):
             atom = node.id
             residue = atom.residue
-            
+
             node.features[Nfeat.ATOMTYPE] = atom.element.onehot
             node.features[Nfeat.PDBOCCUPANCY] = atom.occupancy
             node.features[Nfeat.ATOMCHARGE] = atomic_forcefield.get_charge(atom)
         else:
-            raise TypeError(f"Unexpected node type: {type(node.id)}") 
+            raise TypeError(f"Unexpected node type: {type(node.id)}")
 
         node.features[Nfeat.RESTYPE] = residue.amino_acid.onehot
         node.features[Nfeat.RESCHARGE] = residue.amino_acid.charge

--- a/deeprank2/features/conservation.py
+++ b/deeprank2/features/conservation.py
@@ -31,7 +31,7 @@ def add_features( # pylint: disable=unused-argument
         node.features[Nfeat.PSSM] = profile
         node.features[Nfeat.INFOCONTENT] = pssm_row.information_content
 
-        if single_amino_acid_variant is not None:            
+        if single_amino_acid_variant is not None:
             if residue == single_amino_acid_variant.residue:
                 # only the variant residue can have a variant and wildtype amino acid
                 conservation_wildtype = pssm_row.get_conservation(single_amino_acid_variant.wildtype_amino_acid)

--- a/deeprank2/features/contact.py
+++ b/deeprank2/features/contact.py
@@ -21,7 +21,7 @@ cutoff_13 = 3.6
 cutoff_14 = 4.2
 
 def _get_nonbonded_energy( #pylint: disable=too-many-locals
-    atoms: List[Atom], 
+    atoms: List[Atom],
     distances: npt.NDArray[np.float64],
     ) -> Tuple [npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """Calculates all pairwise electrostatic (Coulomb) and Van der Waals (Lennard Jones) potential energies between all atoms in the structure.
@@ -30,8 +30,8 @@ def _get_nonbonded_energy( #pylint: disable=too-many-locals
     However, the potential tends to 0 at large distance.
 
     Args:
-        atoms (List[Atom]): list of all atoms in the structure 
-        distances (npt.NDArray[np.float64]): matrix of pairwise distances between all atoms in the structure 
+        atoms (List[Atom]): list of all atoms in the structure
+        distances (npt.NDArray[np.float64]): matrix of pairwise distances between all atoms in the structure
             in the format that is the output of scipy.spatial's distance_matrix (i.e. a diagonally symmetric matrix)
 
     Returns:
@@ -70,8 +70,8 @@ def _get_nonbonded_energy( #pylint: disable=too-many-locals
     E_vdw[pair_14] = E_vdw_14pairs[pair_14]
     E_vdw[pair_13] = 0
     E_elec[pair_13] = 0
-    
-    
+
+
     return E_elec, E_vdw
 
 
@@ -79,9 +79,9 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
     pdb_path: str, graph: Graph,
     single_amino_acid_variant: Optional[SingleResidueVariant] = None
     ):
-    
+
     # assign each atoms (from all edges) a unique index
-    all_atoms = set() 
+    all_atoms = set()
     if isinstance(graph.edges[0].id, AtomicContact):
         for edge in graph.edges:
             contact = edge.id
@@ -109,8 +109,8 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
     # assign features
     for edge in graph.edges:
         contact = edge.id
-        
-        if isinstance(contact, AtomicContact):    
+
+        if isinstance(contact, AtomicContact):
             ## find the indices
             atom1_index = atom_dict[contact.atom1]
             atom2_index = atom_dict[contact.atom2]
@@ -130,6 +130,6 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
             edge.features[Efeat.DISTANCE] = np.min([[interatomic_distances[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
             edge.features[Efeat.ELEC] = np.sum([[interatomic_electrostatic_energy[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
             edge.features[Efeat.VDW] = np.sum([[interatomic_vanderwaals_energy[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
-        
+
         # Calculate irrespective of node type
         edge.features[Efeat.COVALENT] = float(edge.features[Efeat.DISTANCE] < covalent_cutoff and edge.features[Efeat.SAMECHAIN])

--- a/deeprank2/features/irc.py
+++ b/deeprank2/features/irc.py
@@ -21,18 +21,18 @@ def _id_from_residue(residue: Tuple[str, int, str]) -> str:
     Args:
         residue (tuple): Input residue as rendered by pdb2sql: ( str(<chain>), int(<residue_number>), str(<three_letter_code> )
             For example: ('A', 27, 'GLU').
-    
+
     Returns:
         str: Output id in form of '<chain><residue_number>'. For example: 'A27'.
     """
-    
+
     return residue[0] + str(residue[1])
 
 
 class _ContactDensity:
     """Internal class that holds contact density information for a given residue.
     """
-    
+
     def __init__(self, residue: Tuple[str, int, str], polarity: Polarity):
         self.res = residue
         self.polarity = polarity
@@ -52,7 +52,7 @@ def get_IRCs(pdb_path: str, chains: List[str], cutoff: float = 5.5) -> Dict[str,
         cutoff (float, optional): Cutoff distance (in Ångström) to be considered a close contact. Defaults to 10.
 
     Returns:
-        Dict[str, _ContactDensity]: 
+        Dict[str, _ContactDensity]:
             keys: ids of residues in form returned by id_from_residue.
             items: _ContactDensity objects, containing all contact density information for the residue.
     """
@@ -61,11 +61,11 @@ def get_IRCs(pdb_path: str, chains: List[str], cutoff: float = 5.5) -> Dict[str,
 
     sql = pdb2sql.interface(pdb_path)
     pdb2sql_contacts = sql.get_contact_residues(
-        cutoff=cutoff, 
+        cutoff=cutoff,
         chain1=chains[0], chain2=chains[1],
         return_contact_pairs=True
     )
-    
+
     for chain1_res, chain2_residues in pdb2sql_contacts.items():
         aa1_code = chain1_res[2]
         try:
@@ -76,20 +76,20 @@ def get_IRCs(pdb_path: str, chains: List[str], cutoff: float = 5.5) -> Dict[str,
         # add chain1_res to residue_contact dict
         contact1_id = _id_from_residue(chain1_res)
         residue_contacts[contact1_id] = _ContactDensity(chain1_res, aa1.polarity)
-        
+
         for chain2_res in chain2_residues:
             aa2_code = chain2_res[2]
             try:
                 aa2 = [amino_acid for amino_acid in amino_acids if amino_acid.three_letter_code == aa2_code][0]
             except IndexError:
                 continue  # skip keys that are not an amino acid
-            
+
             # populate densities and connections for chain1_res
             residue_contacts[contact1_id].densities['total'] += 1
             residue_contacts[contact1_id].densities[aa2.polarity] += 1
             residue_contacts[contact1_id].connections['all'].append(chain2_res)
             residue_contacts[contact1_id].connections[aa2.polarity].append(chain2_res)
-            
+
             # add chain2_res to residue_contact dict if it doesn't exist yet
             contact2_id = _id_from_residue(chain2_res)
             if contact2_id not in residue_contacts:
@@ -100,7 +100,7 @@ def get_IRCs(pdb_path: str, chains: List[str], cutoff: float = 5.5) -> Dict[str,
             residue_contacts[contact2_id].densities[aa1.polarity] += 1
             residue_contacts[contact2_id].connections['all'].append(chain1_res)
             residue_contacts[contact2_id].connections[aa1.polarity].append(chain1_res)
-    
+
     return residue_contacts
 
 
@@ -108,11 +108,11 @@ def add_features(
     pdb_path: str, graph: Graph,
     single_amino_acid_variant: Optional[SingleResidueVariant] = None
     ):
-    
+
     if not single_amino_acid_variant: # VariantQueries do not use this feature
         polarity_pairs = list(combinations(Polarity, 2))
         polarity_pair_string = [f'irc_{x[0].name.lower()}_{x[1].name.lower()}' for x in polarity_pairs]
-        
+
         total_contacts = 0
         residue_contacts = get_IRCs(pdb_path, graph.get_all_chains())
 
@@ -126,11 +126,11 @@ def add_features(
                 raise TypeError(f"Unexpected node type: {type(node.id)}")
 
             contact_id = residue.chain.id + residue.number_string  # reformat id to be in line with residue_contacts keys
-            
+
             # initialize all IRC features to 0
             for IRC_type in Nfeat.IRC_FEATURES:
                 node.features[IRC_type] = 0
-            
+
             # load correct values to IRC features
             try:
                 node.features[Nfeat.IRCTOTAL] = residue_contacts[contact_id].densities['total']

--- a/deeprank2/features/secondary_structure.py
+++ b/deeprank2/features/secondary_structure.py
@@ -51,14 +51,14 @@ def _check_pdb(pdb_path: str):
             lines = [f'HEADER {firstline}'] + lines[1:]
         else:
             lines = ['HEADER \n'] + lines
-    
+
     # check for CRYST1 record
     existing_records = _get_records(lines)
     if 'CRYST1' not in existing_records:
         fix_pdb = True
         dummy_CRYST1 = 'CRYST1   00.000   00.000   00.000  00.00  00.00  00.00 X 00 00 0    00\n'
         lines = [lines[0]] + [dummy_CRYST1] + lines[1:]
-    
+
     # check for unnumbered REMARK lines
     for i, line in enumerate(lines):
         if line.startswith('REMARK'):
@@ -85,19 +85,19 @@ def _classify_secstructure(subtype: str):
 
 def _get_secstructure(pdb_path: str) -> Dict:
     """Process the DSSP output to extract secondary structure information.
-    
+
     Args:
         pdb_path (str): The file path of the PDB file to be processed.
-    
+
     Returns:
         dict: A dictionary containing secondary structure information for each chain and residue.
     """
- 
+
     # Execute DSSP and read the output
     _check_pdb(pdb_path)
     p = PDBParser(QUIET=True)
     model = p.get_structure(Path(pdb_path).stem, pdb_path)[0]
-    
+
     # pylint: disable=raise-missing-from
     try:
         dssp = DSSP(model, pdb_path, dssp='mkdssp')
@@ -115,10 +115,10 @@ def _get_secstructure(pdb_path: str) -> Dict:
     # Store output in Dictionary
     sec_structure_dict = {}
     for chain in set(chain_ids):
-        sec_structure_dict[chain] = {}    
+        sec_structure_dict[chain] = {}
     for i, _ in enumerate(chain_ids):
         sec_structure_dict[chain_ids[i]][res_numbers[i]] = sec_structs[i]
-    
+
     return sec_structure_dict
 
 
@@ -126,7 +126,7 @@ def add_features( # pylint: disable=unused-argument
     pdb_path: str,
     graph: Graph,
     single_amino_acid_variant: Optional[SingleResidueVariant] = None
-    ):    
+    ):
 
     sec_structure_features = _get_secstructure(pdb_path)
 

--- a/deeprank2/features/surfacearea.py
+++ b/deeprank2/features/surfacearea.py
@@ -17,8 +17,8 @@ logging.getLogger(__name__)
 
 
 def add_sasa(pdb_path: str, graph: Graph):
-    structure = freesasa.Structure(pdb_path) 
-    result = freesasa.calc(structure) 
+    structure = freesasa.Structure(pdb_path)
+    result = freesasa.calc(structure)
 
     for node in graph.nodes:
         if isinstance(node.id, Residue):
@@ -43,7 +43,7 @@ def add_sasa(pdb_path: str, graph: Graph):
 
 def add_bsa(graph: Graph):
 
-    sasa_complete_structure = freesasa.Structure() 
+    sasa_complete_structure = freesasa.Structure()
     sasa_chain_structures = {}
 
     for node in graph.nodes:
@@ -51,7 +51,7 @@ def add_bsa(graph: Graph):
             residue = node.id
             chain_id = residue.chain.id
             if chain_id not in sasa_chain_structures:
-                sasa_chain_structures[chain_id] = freesasa.Structure() 
+                sasa_chain_structures[chain_id] = freesasa.Structure()
 
             for atom in residue.atoms:
                 sasa_chain_structures[chain_id].addAtom(atom.name, atom.residue.amino_acid.three_letter_code,
@@ -59,14 +59,14 @@ def add_bsa(graph: Graph):
                                                         atom.position[0], atom.position[1], atom.position[2])
                 sasa_complete_structure.addAtom(atom.name, atom.residue.amino_acid.three_letter_code,
                                                 atom.residue.number, atom.residue.chain.id,
-                                                atom.position[0], atom.position[1], atom.position[2]) 
+                                                atom.position[0], atom.position[1], atom.position[2])
 
         elif isinstance(node.id, Atom):
             atom = node.id
             residue = atom.residue
             chain_id = residue.chain.id
             if chain_id not in sasa_chain_structures:
-                sasa_chain_structures[chain_id] = freesasa.Structure() 
+                sasa_chain_structures[chain_id] = freesasa.Structure()
 
             sasa_chain_structures[chain_id].addAtom(atom.name, atom.residue.amino_acid.three_letter_code,
                                                     atom.residue.number, atom.residue.chain.id,
@@ -80,8 +80,8 @@ def add_bsa(graph: Graph):
         else:
             raise TypeError(f"Unexpected node type: {type(node.id)}")
 
-    sasa_complete_result = freesasa.calc(sasa_complete_structure) 
-    sasa_chain_results = {chain_id: freesasa.calc(structure) 
+    sasa_complete_result = freesasa.calc(sasa_complete_structure)
+    sasa_chain_results = {chain_id: freesasa.calc(structure)
                           for chain_id, structure in sasa_chain_structures.items()}
 
     for node in graph.nodes:
@@ -99,8 +99,8 @@ def add_bsa(graph: Graph):
                  (atom.name, atom.residue.number_string, atom.residue.chain.id),) # pylint: disable=consider-using-f-string
 
         area_monomer = freesasa.selectArea(selection, sasa_chain_structures[chain_id], \
-            sasa_chain_results[chain_id])[area_key] 
-        area_multimer = freesasa.selectArea(selection, sasa_complete_structure, sasa_complete_result)[area_key] 
+            sasa_chain_results[chain_id])[area_key]
+        area_multimer = freesasa.selectArea(selection, sasa_complete_structure, sasa_complete_result)[area_key]
 
         node.features[Nfeat.BSA] = area_monomer - area_multimer
 
@@ -109,7 +109,7 @@ def add_features( # pylint: disable=unused-argument
     pdb_path: str, graph: Graph,
     single_amino_acid_variant: Optional[SingleResidueVariant] = None
     ):
-    
+
     """calculates the Buried Surface Area (BSA) and the Solvent Accessible Surface Area (SASA):
     BSA: the area of the protein, that only gets exposed in monomeric state"""
 

--- a/deeprank2/molstruct/aminoacid.py
+++ b/deeprank2/molstruct/aminoacid.py
@@ -31,7 +31,7 @@ class AminoAcid:
         polarity: Polarity,
         size: int,
         mass: float,
-        pI: float, 
+        pI: float,
         hydrogen_bond_donors: int,
         hydrogen_bond_acceptors: int,
         index: int,

--- a/deeprank2/molstruct/atom.py
+++ b/deeprank2/molstruct/atom.py
@@ -41,7 +41,7 @@ class Atom:
             occupancy (float): Pdb occupancy value.
                 This represents the proportion of structures where the atom is detected at a given position.
                 Sometimes a single atom can be detected at multiple positions. In that case separate structures exist where sum(occupancy) == 1.
-                Note that only the highest occupancy atom is used by deeprank2 (see tools.pdb._add_atom_to_residue) 
+                Note that only the highest occupancy atom is used by deeprank2 (see tools.pdb._add_atom_to_residue)
         """
         self._residue = residue
         self._name = name

--- a/deeprank2/molstruct/residue.py
+++ b/deeprank2/molstruct/residue.py
@@ -43,7 +43,7 @@ class Residue:
         return hash((self._number, self._insertion_code))
 
     def get_pssm(self) -> PssmRow:
-        """ 
+        """
         If the residue's chain has pssm info linked to it,
         then return the part that belongs to this residue.
         """
@@ -95,8 +95,8 @@ class Residue:
 
 
 def get_residue_center(residue: Residue) -> np.ndarray:
-    """Chooses a center position for a residue. 
-    
+    """Chooses a center position for a residue.
+
     Based on the atoms it has:
     1. find beta carbon, if present
     2. find alpha carbon, if present

--- a/deeprank2/neuralnets/gnn/naive_gnn.py
+++ b/deeprank2/neuralnets/gnn/naive_gnn.py
@@ -1,4 +1,4 @@
-# Example of network that doesn't require clusters.  
+# Example of network that doesn't require clusters.
 
 import torch
 from torch.nn import Linear, Module, ReLU, Sequential

--- a/deeprank2/query.py
+++ b/deeprank2/query.py
@@ -45,7 +45,7 @@ def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str], suppress: bool, verbo
         verbosity (int): Level of verbosity of error/warning. Defaults to 0.
             0 (low): Only state file name where error occurred;
             1 (medium): Also state number of incorrect and missing residues;
-            2 (high): Also list the incorrect residues 
+            2 (high): Also list the incorrect residues
 
     Raises:
         ValueError: Raised if info between pdb file and pssm file doesn't match or if no pssms were provided
@@ -69,7 +69,7 @@ def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str], suppress: bool, verbo
     missing_list = []
 
     for residue in pdb_truth:
-        try: 
+        try:
             if pdb_truth[residue] != pssm_data[residue]:
                 wrong_list.append(residue)
         except KeyError:
@@ -86,10 +86,10 @@ def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str], suppress: bool, verbo
                 error_message = error_message + f'\n\t{len(missing_list)} entries are missing.'
                 if verbosity == 2:
                     error_message = error_message[-1] + f':\n\t{missing_list}'
-    
+
         if not suppress:
             raise ValueError(error_message)
-        
+
         warnings.warn(error_message)
         _log.warning(error_message)
 
@@ -181,7 +181,7 @@ class Query:
 
     def __repr__(self) -> str:
         return f"{type(self)}({self.get_query_id()})"
-    
+
     def build(self, feature_modules: List[ModuleType], include_hydrogens: bool = False) -> Graph:
         raise NotImplementedError("Must be defined in child classes.")
     def get_query_id(self) -> str:
@@ -192,7 +192,7 @@ class QueryCollection:
     """
     Represents the collection of data queries.
         Queries can be saved as a dictionary to easily navigate through their data.
-    
+
     """
 
     def __init__(self):
@@ -207,7 +207,7 @@ class QueryCollection:
 
         Args:
             query(:class:`Query`): Must be a :class:`Query` object, either :class:`ProteinProteinInterfaceResidueQuery` or
-                :class:`SingleResidueVariantAtomicQuery`.    
+                :class:`SingleResidueVariantAtomicQuery`.
             verbose(bool, optional): For logging query IDs added, defaults to False.
             warn_duplicate (bool): Log a warning before renaming if a duplicate query is identified.
 
@@ -223,7 +223,7 @@ class QueryCollection:
             self.ids_count[query_id] += 1
             new_id = query.model_id + "_" + str(self.ids_count[query_id])
             query.model_id = new_id
-            
+
             if warn_duplicate:
                 _log.warning(f'Query with ID {query_id} has already been added to the collection. Renaming it as {query.get_query_id()}')
 
@@ -231,13 +231,13 @@ class QueryCollection:
 
     def export_dict(self, dataset_path: str):
         """Exports the colection of all queries to a dictionary file.
-        
+
         Args:
             dataset_path (str): The path where to save the list of queries.
         """
         with open(dataset_path, "wb") as pkl_file:
-            pickle.dump(self, pkl_file)    
-            
+            pickle.dump(self, pkl_file)
+
     @property
     def queries(self) -> List[Query]:
         "The list of queries added to the collection."
@@ -290,7 +290,7 @@ class QueryCollection:
             return None
 
     def process( # pylint: disable=too-many-arguments, too-many-locals, dangerous-default-value
-        self, 
+        self,
         prefix: Optional[str] = None,
         feature_modules: Union[ModuleType, List[ModuleType], str, List[str]] = [components, contact],
         cpu_count: Optional[int] = None,
@@ -303,8 +303,8 @@ class QueryCollection:
         Args:
             prefix (Optional[str], optional): Prefix for the output files. Defaults to None, which sets ./processed-queries- prefix.
             feature_modules (Union[ModuleType, List[ModuleType], str, List[str]], optional): Features' module or list of features' modules
-                used to generate features (given as string or as an imported module). Each module must implement the :py:func:`add_features` function, 
-                and features' modules can be found (or should be placed in case of a custom made feature) in `deeprank2.features` folder. 
+                used to generate features (given as string or as an imported module). Each module must implement the :py:func:`add_features` function,
+                and features' modules can be found (or should be placed in case of a custom made feature) in `deeprank2.features` folder.
                 If set to 'all', all available modules in `deeprank2.features` are used to generate the features.
                 Defaults to only the basic feature modules `deeprank2.features.components` and `deeprank2.features.contact`.
             cpu_count (Optional[int], optional): How many processes to be run simultaneously. Defaults to None, which takes all available cpu cores.
@@ -315,7 +315,7 @@ class QueryCollection:
                 Defaults to None.
             grid_augmentation_count (int, optional): Number of grid data augmentations. May not be negative be zero or a positive number.
                 Defaults to 0.
-        
+
         Returns:
             List[str]: The list of paths of the generated HDF5 files.
         """
@@ -339,7 +339,7 @@ class QueryCollection:
         if feature_modules == 'all':
             feature_names = [modname for _, modname, _ in pkgutil.iter_modules(deeprank2.features.__path__)]
         elif isinstance(feature_modules, list):
-            feature_names = [os.path.basename(m.__file__)[:-3] if isinstance(m,ModuleType) 
+            feature_names = [os.path.basename(m.__file__)[:-3] if isinstance(m,ModuleType)
                              else m.replace('.py','') for m in feature_modules]
         elif isinstance(feature_modules, ModuleType):
             feature_names = [os.path.basename(feature_modules.__file__)[:-3]]
@@ -445,7 +445,7 @@ class SingleResidueVariantResidueQuery(Query):
             include_hydrogens (bool, optional): Whether to include hydrogens in the :class:`Graph`. Defaults to False.
 
         Returns:
-            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets. 
+            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets.
         """
 
         # load .PDB structure
@@ -518,7 +518,7 @@ class SingleResidueVariantAtomicQuery(Query):
             wildtype_amino_acid (:class:`AminoAcid`): The wildtype amino acid.
             variant_amino_acid (:class:`AminoAcid`): The variant amino acid.
             pssm_paths (Optional[Dict(str,str)], optional): The paths to the .PSSM files, per chain identifier. Defaults to None.
-            radius (float, optional): In Ångström, determines how many residues will be included in the graph. Defaults to 10.0. 
+            radius (float, optional): In Ångström, determines how many residues will be included in the graph. Defaults to 10.0.
             distance_cutoff (Optional[float], optional): Max distance in Ångström between a pair of atoms to consider them as an external edge in the graph.
                 Defaults to 4.5.
             targets (Optional[Dict(str,float)], optional): Named target values associated with this query. Defaults to None.
@@ -595,7 +595,7 @@ class SingleResidueVariantAtomicQuery(Query):
             include_hydrogens (bool, optional): Whether to include hydrogens in the :class:`Graph`. Defaults to False.
 
         Returns:
-            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets. 
+            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets.
         """
 
         # load .PDB structure
@@ -763,7 +763,7 @@ class ProteinProteinInterfaceAtomicQuery(Query):
             include_hydrogens (bool, optional): Whether to include hydrogens in the :class:`Graph`. Defaults to False.
 
         Returns:
-            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets. 
+            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets.
         """
 
         contact_atoms = _load_ppi_atoms(self._pdb_path,
@@ -861,7 +861,7 @@ class ProteinProteinInterfaceResidueQuery(Query):
             include_hydrogens (bool, optional): Whether to include hydrogens in the :class:`Graph`. Defaults to False.
 
         Returns:
-            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets. 
+            :class:`Graph`: The resulting :class:`Graph` object with all the features and targets.
         """
 
         contact_atoms = _load_ppi_atoms(self._pdb_path,

--- a/deeprank2/tools/target.py
+++ b/deeprank2/tools/target.py
@@ -87,7 +87,7 @@ def compute_targets(pdb_path: str, reference_pdb_path: str) -> Dict[str, Union[f
 
     """
     Compute targets and outputs them as a dictionary.
-    For classification: 
+    For classification:
        - binary (scalar value is expected to be either 0 or 1)
        - capri_classes (scalar integer values are expected)
     For regression:

--- a/deeprank2/tools/visualization/plotting.py
+++ b/deeprank2/tools/visualization/plotting.py
@@ -222,7 +222,7 @@ def plotly_2d( # noqa
                 first_chain = graph.nodes[node][Nfeat.CHAINID]
             if graph.nodes[node][Nfeat.CHAINID] != first_chain: # This is not very pythonic, but somehow I'm stuck on how to do this without enumerating
                 index = 1
-        
+
         pos = graph.nodes[node]["pos2d"]
 
         node_trace[index]["x"] += (pos[0],)

--- a/deeprank2/utils/buildgraph.py
+++ b/deeprank2/utils/buildgraph.py
@@ -122,7 +122,7 @@ def get_structure(pdb, id_: str):
         pdb (pdb2sql object): The pdb structure that we're investigating.
         id (str): Unique id for the pdb structure.
 
-    Returns: 
+    Returns:
         PDBStructure: The structure object, giving access to chains, residues, atoms.
     """
 
@@ -226,7 +226,7 @@ def get_residue_contact_pairs( # pylint: disable=too-many-locals
         chain_id2 (str): Second protein chain identifier.
         distance_cutoff (float): Max distance between two interacting residues.
 
-    Returns: 
+    Returns:
         List[Pair]: The pairs of contacting residues.
     """
 
@@ -296,7 +296,7 @@ def get_surrounding_residues(structure: Union[Chain, PDBStructure], residue: Res
         residue (:class:`Residue`): The residue in the structure.
         radius (float): Max distance in Ångström between atoms of the residue and the other residues.
 
-    Returns: 
+    Returns:
         (a set of deeprank residues): The surrounding residues.
     """
 

--- a/deeprank2/utils/community_pooling.py
+++ b/deeprank2/utils/community_pooling.py
@@ -169,7 +169,7 @@ def community_pooling(cluster, data):
         pooled features tensor
 
     Examples:
-    
+
         >>> import torch
         >>> from torch_geometric.data import Data, Batch
         >>> edge_index = torch.tensor([[0, 1, 1, 2, 3, 4, 4, 5],

--- a/deeprank2/utils/earlystopping.py
+++ b/deeprank2/utils/earlystopping.py
@@ -24,10 +24,10 @@ class EarlyStopping:
                 Defaults to None.
             min_epoch (float, optional): Minimum epoch to be reached before looking at maxgap.
                 Defaults to 10.
-            verbose (bool, optional): If True, prints a message for each validation loss improvement. 
+            verbose (bool, optional): If True, prints a message for each validation loss improvement.
                 Defaults to True.
             trace_func (Callable, optional): Function used for recording EarlyStopping status.
-                Defaults to print.            
+                Defaults to print.
         """
 
         self.patience = patience
@@ -44,12 +44,12 @@ class EarlyStopping:
 
     def __call__(self, epoch, val_loss, train_loss=None):
         score = -val_loss
-        
+
         # initialize
         if self.best_score is None:
             self.best_score = score
             self.val_loss_min = val_loss
-        
+
         # check patience
         elif score < self.best_score + self.delta:
             self.counter += 1
@@ -68,11 +68,11 @@ class EarlyStopping:
                 self.trace_func(f'Validation loss decreased ({self.val_loss_min:.6f} --> {val_loss:.6f}).')
             self.best_score = score
             self.counter = 0
-        
+
         if score >= self.best_score:
             self.best_score = score
             self.val_loss_min = val_loss
-        
+
         # check maxgap
         if self.maxgap and epoch > self.min_epoch:
             if train_loss is None:
@@ -82,7 +82,7 @@ class EarlyStopping:
                 self.trace_func(f'EarlyStopping activated at epoch # {epoch} due to overfitting. ' +
                                 f'The difference between validation and training loss of {gap} exceeds the maximum allowed ({self.maxgap})')
                 self.early_stop = True
-                
+
 
 
 

--- a/deeprank2/utils/exporters.py
+++ b/deeprank2/utils/exporters.py
@@ -18,7 +18,7 @@ class OutputExporter:
     """The class implements a general exporter to be called when a neural network generates outputs."""
 
     def __init__(self, directory_path: str = None):
-        
+
         if directory_path is None:
             directory_path = "./output"
         self._directory_path = directory_path
@@ -153,7 +153,7 @@ class ScatterPlotExporter(OutputExporter):
     """
 
     def __init__(self, directory_path: str, epoch_interval: int = 1):
-        """ 
+        """
         Args:
             directory_path (str): Where to store the plots.
             epoch_interval (int, optional): How often to make a plot, 5 means: every 5 epochs. Defaults to 1.
@@ -265,7 +265,7 @@ class HDF5OutputExporter(OutputExporter):
     def process( # pylint: disable=too-many-arguments
         self,
         pass_name: str,
-        epoch_number: int, 
+        epoch_number: int,
         entry_names: List[str],
         output_values: List[Any],
         target_values: List[Any],

--- a/deeprank2/utils/graph.py
+++ b/deeprank2/utils/graph.py
@@ -308,7 +308,7 @@ class Graph:
                     targets_group[target_name][()] = target_data
 
         return hdf5_path
-    
+
     def get_all_chains(self) -> List[str]:
         if isinstance(self.nodes[0].id, Residue):
             chains = set(str(res.chain).split()[1] for res in [node.id for node in self.nodes])
@@ -358,7 +358,7 @@ def build_residue_graph( # pylint: disable=too-many-locals
     residues: List[Residue], graph_id: str, edge_distance_cutoff: float
 ) -> Graph:
     """Builds a graph, using the residues as nodes.
-    
+
     The edge distance cutoff is in Ångströms.
     It's the shortest interatomic distance between two residues.
     """

--- a/deeprank2/utils/grid.py
+++ b/deeprank2/utils/grid.py
@@ -282,7 +282,7 @@ class Grid:
         method: MapMethod,
     ):
         """Maps point feature data at a given position to the grid, using the given method.
-        
+
         The feature_value should either be a single number or a one-dimensional array.
         """
 

--- a/deeprank2/utils/parsing/vdwparam.py
+++ b/deeprank2/utils/parsing/vdwparam.py
@@ -9,7 +9,7 @@ class VanderwaalsParam:
         self.sigma_main = sigma_main
         self.epsilon_14 = epsilon_14
         self.sigma_14 = sigma_14
-    
+
     def __str__(self) -> str:
         return f"{self.epsilon_main}, {self.sigma_main}, {self.epsilon_14}, {self.sigma_14}"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ doc =
     sphinx_rtd_theme
 test =
     pytest
-    pylint <= 2.15.3  
+    pylint <= 2.15.3
     prospector[with_pyroma] <= 1.7.7
     bump2version
     coverage
@@ -74,7 +74,7 @@ publishing =
     build
     twine
     wheel
-tutorials = 
+tutorials =
     notebook
     pytest
     plotly

--- a/tests/features/__init__.py
+++ b/tests/features/__init__.py
@@ -24,9 +24,9 @@ def _get_residue(chain: Chain, number: int) -> Residue:
 
 
 def build_testgraph( # pylint: disable=too-many-locals, too-many-arguments # noqa:MC0001
-    pdb_path: str, 
-    cutoff: float, 
-    detail: str, 
+    pdb_path: str,
+    cutoff: float,
+    detail: str,
     central_res: Optional[int] = None,
     variant: Optional[AminoAcid] = None,
     chain_ids: Optional[Union[str, Tuple[str, str]]] = None,
@@ -43,7 +43,7 @@ def build_testgraph( # pylint: disable=too-many-locals, too-many-arguments # noq
             Defaults to None.
         variant (Optional[AminoAcid], optional): Amino acid to use as a variant amino acid.
             Defaults to None.
-        chain_ids (Optional[Union[str, Tuple[str, str]]], optional): Explicitly specify which chain(s) to use. 
+        chain_ids (Optional[Union[str, Tuple[str, str]]], optional): Explicitly specify which chain(s) to use.
             Defaults to None, which will use the first (two) chain(s) from the structure.
 
     Raises:
@@ -67,14 +67,14 @@ def build_testgraph( # pylint: disable=too-many-locals, too-many-arguments # noq
         else:
             chains = [structure.get_chain(chain_id) for chain_id in chain_ids]
         for residue1, residue2 in get_residue_contact_pairs(
-            pdb_path, structure, 
-            chains[0], chains[1], 
+            pdb_path, structure,
+            chains[0], chains[1],
             cutoff
         ):
             if detail == 'residue':
                 nodes.add(residue1)
                 nodes.add(residue2)
-            
+
             elif detail == 'atom':
                 for atom in residue1.atoms:
                     nodes.add(atom)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -585,10 +585,10 @@ class TestDataSet(unittest.TestCase):
 
     def test_only_transform_all_graphdataset(self):# noqa: MC0001, pylint: disable=too-many-locals
         # define a features_transform dict for only transformations for `all` features
-        
+
         hdf5_path = "tests/data/hdf5/train.hdf5"
         features_transform = {'all': {'transform': lambda t: np.log(abs(t)+.01)}}
-        
+
         # dataset that has the transformations applied using features_transform dict
         transf_dataset = GraphDataset(
             hdf5_path = hdf5_path,
@@ -911,10 +911,10 @@ class TestDataSet(unittest.TestCase):
         assert dataset_train.devs == dataset_test.devs
 
     def test_invalid_value_features_transform(self):
-        
+
         hdf5_path = "tests/data/hdf5/train.hdf5"
         features_transform = {'all': {'transform': lambda t: np.log(t+10), 'standardize': True}}
-        
+
         transf_dataset = GraphDataset(
             hdf5_path = hdf5_path,
             target = 'binary',
@@ -923,7 +923,7 @@ class TestDataSet(unittest.TestCase):
         with pytest.raises(ValueError):
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore', r'divide by zero encountered in divide')
-                _compute_features_with_get(hdf5_path, transf_dataset)     
+                _compute_features_with_get(hdf5_path, transf_dataset)
 
     def test_inherit_info_training_graphdataset(self):
         hdf5_path = "tests/data/hdf5/train.hdf5"


### PR DESCRIPTION
Please test to see if it works as intended (my VS code settings do this anyway, so not sure I wrote it correct here).

Also, do we want to do this for all filetypes instead? I noticed that *.pdbs have a lot of trailing whitespaces, but those might be part of the filestructure....

closes #479