### PR TITLE
fix: features transform in `Trainer._save_model` internal method

### DIFF
--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -947,7 +947,7 @@ class Trainer:
                 if key["transform"] is None:
                     continue
                 str_expr = inspect.getsource(key["transform"])
-                match = re.search(r"\'transform\':.*(lambda.*).*,.*\'standardize\'.*", str_expr).group(1)
+                match = re.search(r"[\"|\']transform[\"|\']:.*(lambda.*).*,.*[\"|\']standardize[\"|\'].*", str_expr).group(1)
                 key["transform"] = match
 
         state = {

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,5 +1,4 @@
 import glob
-import inspect
 import logging
 import os
 import shutil
@@ -8,7 +7,6 @@ import unittest
 import warnings
 
 import h5py
-import numpy as np
 import pandas as pd
 import pytest
 import torch

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,4 +1,5 @@
 import glob
+import inspect
 import logging
 import os
 import shutil
@@ -7,6 +8,7 @@ import unittest
 import warnings
 
 import h5py
+import numpy as np
 import pandas as pd
 import pytest
 import torch
@@ -760,6 +762,37 @@ class TestTrainer(unittest.TestCase):
         assert len(output) == len(dataset_test)
         assert output.target.unique().tolist()[0] is None
         assert output.loss.unique().tolist()[0] is None
+
+    def test_graph_save_and_load_model(self) -> None:
+        test_data_graph = "tests/data/hdf5/test.hdf5"
+        n = 10
+        features_transform = {
+            Nfeat.RESTYPE: {"transform": lambda x: x / 2, "standardize": True},
+            Nfeat.BSA: {"transform": None, "standardize": False},
+        }
+
+        dataset = GraphDataset(
+            hdf5_path=test_data_graph,
+            node_features=[Nfeat.RESTYPE, Nfeat.POLARITY, Nfeat.BSA],
+            target=targets.BINARY,
+            task=targets.CLASSIF,
+            features_transform=features_transform,
+        )
+        trainer = Trainer(NaiveNetwork, dataset)
+        # during the training the model is saved
+        trainer.train(nepoch=2, batch_size=2, filename=self.save_path)
+        assert trainer.features_transform == features_transform
+
+        # load the model into a new GraphDataset instance
+        dataset_test = GraphDataset(
+            hdf5_path="tests/data/hdf5/test.hdf5",
+            train_source=self.save_path,
+        )
+
+        # Check if the features_transform is correctly loaded from the saved model
+        assert dataset_test.features_transform[Nfeat.RESTYPE]["transform"](n) == n / 2  # the only way to test the transform in this case is to apply it
+        assert dataset_test.features_transform[Nfeat.RESTYPE]["standardize"] == features_transform[Nfeat.RESTYPE]["standardize"]
+        assert dataset_test.features_transform[Nfeat.BSA] == features_transform[Nfeat.BSA]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- The bug was due to the quotation marks type used in the regex for extracting the transform function. The quotation marks are indeed now automatically fixed to double type by ruff in our VSCode editor. Since a user should be able to use both types of quotation marks, I changed the regex that matches the `transform` function for handling both cases. The bug was causing the failure of the `training.ipynb` notebook.
- I also added a test for checking on the `features_transform` attribute in the `Trainer`, and in case we use a pre-trained model. The testing on the trainer side for features_transform was missing. 

As soon as this is approved, I will release a new patch version for deeprank2. 