### PR TITLE
docs: improve handling pypi packaging contents and add NOTICE

### DIFF
--- a/.github/workflows/build-latest-release.yml
+++ b/.github/workflows/build-latest-release.yml
@@ -18,6 +18,11 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"] # ["3.10", "3.11"]
 
+    # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           extras-require: publishing
           pkg-installation-type: "repository"
       - name: Build wheel and source distribution
-        run: python -m build
+        run: python3 -m build
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.10"]
 
+    # https://github.com/marketplace/actions/setup-miniconda#use-a-default-shell
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/install-python-and-package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include env/deeprank2.yml
+include CITATION.cff
+include LICENSE
+include NOTICE
+prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include CITATION.cff
-include LICENSE
-include NOTICE
-include README.md
-include env/deeprank2.yml
-prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include CITATION.cff
+include LICENSE
+include NOTICE
+include README.md
+include env/deeprank2.yml
+prune tests

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright 2022, Giulia Crocioni, Dani L. Bodor, The Netherlands eScience Center, Li C. Xue, RadboudUMC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,7 @@ branch = true
 source = ["deeprank2"]
 
 [tool.setuptools.packages.find]
-include = ["deeprank2*", "README.md", "env/deeprank2.yml", "CITATION.cff", "LICENSE", "NOTICE"]
-exclude = ["tests", "tests*", "*tests.*", "*tests"]
+include = ["deeprank2*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.xlsx", "*.param", "*.top", "*residue-classes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ branch = true
 source = ["deeprank2"]
 
 [tool.setuptools.packages.find]
-include = ["deeprank2*"]
+include = ["deeprank2*", "LICENSE", "README.md", "CITATION.cff", "NOTICE"]
 exclude = ["tests", "tests*", "*tests.*", "*tests"]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ branch = true
 source = ["deeprank2"]
 
 [tool.setuptools.packages.find]
-include = ["deeprank2*", "LICENSE", "README.md", "CITATION.cff", "NOTICE"]
+include = ["deeprank2*", "README.md", "env/deeprank2.yml", "CITATION.cff", "LICENSE", "NOTICE"]
 exclude = ["tests", "tests*", "*tests.*", "*tests"]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
The PyPI release 3.0.2 still contains the tests folder. Using a MANIFEST.in where we prune (exclude) the tests should fix the issue. We will verify this in the next release (not a major issue). Also, I created a NOTICE file for the copyright, that was missing.