### PR TITLE
docs: improve handling pypi packaging contents and add NOTICE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.md
+include env/deeprank2.yml
+include CITATION.cff
+include LICENSE
+include NOTICE
+prune tests

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright 2022, Giulia Crocioni, Dani L. Bodor, The Netherlands eScience Center, Li C. Xue, RadboudUMC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ source = ["deeprank2"]
 
 [tool.setuptools.packages.find]
 include = ["deeprank2*"]
-exclude = ["tests", "tests*", "*tests.*", "*tests"]
 
 [tool.setuptools.package-data]
 "*" = ["*.xlsx", "*.param", "*.top", "*residue-classes"]


### PR DESCRIPTION
The PyPI release 3.0.2 still contains the tests folder. Using a MANIFEST.in where we prune (exclude) the tests should fix the issue. We will verify this in the next release (not a major issue). Also, I created a NOTICE file for the copyright, that was missing.