### PR TITLE
fix: OSError when retrieving source code for lambda functions

### DIFF
--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -950,7 +950,7 @@ class Trainer:
                 # Serialize the function
                 serialized_func = dill.dumps(key["transform"])
                 # Deserialize the function
-                deserialized_func = dill.loads(serialized_func)
+                deserialized_func = dill.loads(serialized_func)  # noqa: S301
                 str_expr = inspect.getsource(deserialized_func)
                 match = re.search(r"[\"|\']transform[\"|\']:.*(lambda.*).*,.*[\"|\']standardize[\"|\'].*", str_expr).group(1)
                 key["transform"] = match

--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -6,6 +6,7 @@ import warnings
 from time import time
 from typing import Any
 
+import dill
 import h5py
 import numpy as np
 import torch
@@ -946,7 +947,11 @@ class Trainer:
             for key in features_transform_to_save.values():
                 if key["transform"] is None:
                     continue
-                str_expr = inspect.getsource(key["transform"])
+                # Serialize the function
+                serialized_func = dill.dumps(key["transform"])
+                # Deserialize the function
+                deserialized_func = dill.loads(serialized_func)
+                str_expr = inspect.getsource(deserialized_func)
                 match = re.search(r"[\"|\']transform[\"|\']:.*(lambda.*).*,.*[\"|\']standardize[\"|\'].*", str_expr).group(1)
                 key["transform"] = match
 

--- a/deeprank2/utils/grid.py
+++ b/deeprank2/utils/grid.py
@@ -7,7 +7,7 @@ from enum import Enum
 import h5py
 import numpy as np
 from numpy.typing import NDArray
-from scipy.signal import bspline
+from scipy.interpolate import BSpline
 
 from deeprank2.domain import gridstorage
 
@@ -190,9 +190,9 @@ class Grid:
 
         fx, fy, fz = position
         bsp_data = (
-            bspline((self.xgrid - fx) / self._settings.resolutions[0], order)
-            * bspline((self.ygrid - fy) / self._settings.resolutions[1], order)
-            * bspline((self.zgrid - fz) / self._settings.resolutions[2], order)
+            BSpline((self.xgrid - fx) / self._settings.resolutions[0], order)
+            * BSpline((self.ygrid - fy) / self._settings.resolutions[1], order)
+            * BSpline((self.zgrid - fz) / self._settings.resolutions[2], order)
         )
 
         return value * bsp_data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ autodoc_mock_imports = [
     "scipy",
     "h5py",
     "sklearn",
-    "scipy.signal",
+    "scipy.interpolate",
     "torch",
     "torch.utils",
     "torch.utils.data",

--- a/env/deeprank2-docker.yml
+++ b/env/deeprank2-docker.yml
@@ -25,7 +25,7 @@ dependencies:
   - pytorch-spline-conv>=1.2.2
   - tables>=3.8.0
   - numpy>=1.21.5
-  - scipy>=1.11.2
+  - scipy>=1.13.1
   - h5py>=3.6.0
   - networkx>=2.6.3
   - matplotlib>=3.5.1

--- a/env/deeprank2.yml
+++ b/env/deeprank2.yml
@@ -25,7 +25,7 @@ dependencies:
   - pytorch-spline-conv>=1.2.2
   - tables>=3.8.0
   - numpy>=1.21.5
-  - scipy>=1.11.2
+  - scipy>=1.13.1
   - h5py>=3.6.0
   - networkx>=2.6.3
   - matplotlib>=3.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,7 @@ exclude = ["tests", "tests*", "*tests.*", "*tests"]
 
 [tool.pytest.ini_options]
 # pytest options: -ra: show summary info for all test outcomes
-# -n auto: run tests in parallel
-addopts = "-ra -n auto"  
+addopts = "-ra"  
 
 [tool.ruff]
 line-length = 159

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ exclude = ["tests", "tests*", "*tests.*", "*tests"]
 [tool.setuptools.package-data]
 "*" = ["*.xlsx", "*.param", "*.top", "*residue-classes"]
 
+[tool.pytest.ini_options]
+# pytest options: -ra: show summary info for all test outcomes
+# -n auto: run tests in parallel
+addopts = "-ra -n auto"  
+
 [tool.ruff]
 line-length = 159
 


### PR DESCRIPTION
While training a big network I got: `OSError: could not get source code` from the `_save_model()` method of the `Trainer` class, in particular when we do `str_expr = inspect.getsource(key["transform"])`. The error indicates that the inspect module is unable to retrieve the source code for the lambda function stored in `key["transform"]`.

- I fixed it by using `dill` to serialize and deserialize the functions, which appears to be more reliable.
- I changed the `scipy.signal.bspline` import to `scipy.interpolate.BSpline` to be up to date with a more recent version of scipy (minimum 1.13.1) as indicated in one of their latest releases ([1.13.0](https://github.com/scipy/scipy/releases/tag/v1.13.0)). I did this since we prefer to not fix the versions, but just to indicate the minimum, and the previous requirement on scipy made the tests break because of this expired deprecation. 