### PR TITLE
ci: simplify lint action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    name: Linting build
+    name: Linting
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -46,11 +46,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/install-python-and-package
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          extras-require: test
-      - name: Check style against standards using ruff
+      - name: Python info
+        shell: bash -l {0}
         run: |
-          ruff check
-          ruff format --check
+          which python3
+          python3 --version
+      - name: Check linting and formatting using ruff
+        run: |
+          python3 -m pip install ruff
+          ruff check || echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1)
+          ruff format --check || echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1)

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -58,5 +58,5 @@ jobs:
       - name: Check linting and formatting using ruff
         run: |
           python3 -m pip install ruff
-          ruff check || echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1)
-          ruff format --check || echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1)
+          ruff check || (echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1))
+          ruff format --check || (echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally." && (exit 1))


### PR DESCRIPTION
Linting doesn't require the entire package to be built, merely ruff to be installed.

Note that the lint action only takes 7 sec now, compared to e.g. 5 min in #611 