### PR TITLE
style: make torch.nn imports more uniform

### DIFF
--- a/deeprank2/neuralnets/cnn/model3d.py
+++ b/deeprank2/neuralnets/cnn/model3d.py
@@ -1,7 +1,7 @@
 import torch
-import torch.nn
-import torch.nn.functional as F
+from torch import nn
 from torch.autograd import Variable
+from torch.nn.functional import relu
 
 # ruff: noqa: ANN001, ANN201, ANN202
 
@@ -23,19 +23,19 @@ from torch.autograd import Variable
 # ----------------------------------------------------------------------
 
 
-class CnnRegression(torch.nn.Module):  # noqa: D101
+class CnnRegression(nn.Module):  # noqa: D101
     def __init__(self, num_features: int, box_shape: tuple[int]):
         super().__init__()
 
-        self.convlayer_000 = torch.nn.Conv3d(num_features, 4, kernel_size=2)
-        self.convlayer_001 = torch.nn.MaxPool3d((2, 2, 2))
-        self.convlayer_002 = torch.nn.Conv3d(4, 5, kernel_size=2)
-        self.convlayer_003 = torch.nn.MaxPool3d((2, 2, 2))
+        self.convlayer_000 = nn.Conv3d(num_features, 4, kernel_size=2)
+        self.convlayer_001 = nn.MaxPool3d((2, 2, 2))
+        self.convlayer_002 = nn.Conv3d(4, 5, kernel_size=2)
+        self.convlayer_003 = nn.MaxPool3d((2, 2, 2))
 
         size = self._get_conv_output(num_features, box_shape)
 
-        self.fclayer_000 = torch.nn.Linear(size, 84)
-        self.fclayer_001 = torch.nn.Linear(84, 1)
+        self.fclayer_000 = nn.Linear(size, 84)
+        self.fclayer_001 = nn.Linear(84, 1)
 
     def _get_conv_output(self, num_features: int, shape: tuple[int]):
         num_data_points = 2
@@ -44,16 +44,16 @@ class CnnRegression(torch.nn.Module):  # noqa: D101
         return output.data.view(num_data_points, -1).size(1)
 
     def _forward_features(self, x):
-        x = F.relu(self.convlayer_000(x))
+        x = relu(self.convlayer_000(x))
         x = self.convlayer_001(x)
-        x = F.relu(self.convlayer_002(x))
+        x = relu(self.convlayer_002(x))
         x = self.convlayer_003(x)
         return x  # noqa:RET504 (unnecessary-assign)
 
     def forward(self, data):
         x = self._forward_features(data.x)
         x = x.view(x.size(0), -1)
-        x = F.relu(self.fclayer_000(x))
+        x = relu(self.fclayer_000(x))
         x = self.fclayer_001(x)
         return x  # noqa:RET504 (unnecessary-assign)
 
@@ -76,19 +76,19 @@ class CnnRegression(torch.nn.Module):  # noqa: D101
 # ----------------------------------------------------------------------
 
 
-class CnnClassification(torch.nn.Module):  # noqa: D101
+class CnnClassification(nn.Module):  # noqa: D101
     def __init__(self, num_features, box_shape):
         super().__init__()
 
-        self.convlayer_000 = torch.nn.Conv3d(num_features, 4, kernel_size=2)
-        self.convlayer_001 = torch.nn.MaxPool3d((2, 2, 2))
-        self.convlayer_002 = torch.nn.Conv3d(4, 5, kernel_size=2)
-        self.convlayer_003 = torch.nn.MaxPool3d((2, 2, 2))
+        self.convlayer_000 = nn.Conv3d(num_features, 4, kernel_size=2)
+        self.convlayer_001 = nn.MaxPool3d((2, 2, 2))
+        self.convlayer_002 = nn.Conv3d(4, 5, kernel_size=2)
+        self.convlayer_003 = nn.MaxPool3d((2, 2, 2))
 
         size = self._get_conv_output(num_features, box_shape)
 
-        self.fclayer_000 = torch.nn.Linear(size, 84)
-        self.fclayer_001 = torch.nn.Linear(84, 2)
+        self.fclayer_000 = nn.Linear(size, 84)
+        self.fclayer_001 = nn.Linear(84, 2)
 
     def _get_conv_output(self, num_features, shape):
         inp = Variable(torch.rand(1, num_features, *shape))
@@ -96,15 +96,15 @@ class CnnClassification(torch.nn.Module):  # noqa: D101
         return out.data.view(1, -1).size(1)
 
     def _forward_features(self, x):
-        x = F.relu(self.convlayer_000(x))
+        x = relu(self.convlayer_000(x))
         x = self.convlayer_001(x)
-        x = F.relu(self.convlayer_002(x))
+        x = relu(self.convlayer_002(x))
         x = self.convlayer_003(x)
         return x  # noqa:RET504 (unnecessary-assign)
 
     def forward(self, data):
         x = self._forward_features(data.x)
         x = x.view(x.size(0), -1)
-        x = F.relu(self.fclayer_000(x))
+        x = relu(self.fclayer_000(x))
         x = self.fclayer_001(x)
         return x  # noqa:RET504 (unnecessary-assign)

--- a/deeprank2/neuralnets/gnn/foutnet.py
+++ b/deeprank2/neuralnets/gnn/foutnet.py
@@ -1,7 +1,6 @@
 import torch
-import torch.nn.functional as F
 from torch import nn
-from torch.nn import Parameter
+from torch.nn.functional import relu
 from torch_geometric.nn import max_pool_x
 from torch_geometric.nn.inits import uniform
 from torch_scatter import scatter_mean
@@ -11,7 +10,7 @@ from deeprank2.utils.community_pooling import community_pooling, get_preloaded_c
 # ruff: noqa: ANN001, ANN201
 
 
-class FoutLayer(torch.nn.Module):
+class FoutLayer(nn.Module):
     """FoutLayer.
 
     This layer is described by eq. (1) of
@@ -32,11 +31,11 @@ class FoutLayer(torch.nn.Module):
         self.out_channels = out_channels
 
         # Wc and Wn are the center and neighbor weight matrix
-        self.wc = Parameter(torch.Tensor(in_channels, out_channels))
-        self.wn = Parameter(torch.Tensor(in_channels, out_channels))
+        self.wc = nn.Parameter(torch.Tensor(in_channels, out_channels))
+        self.wn = nn.Parameter(torch.Tensor(in_channels, out_channels))
 
         if bias:
-            self.bias = Parameter(torch.Tensor(out_channels))
+            self.bias = nn.Parameter(torch.Tensor(out_channels))
         else:
             self.register_parameter("bias", None)
 
@@ -72,7 +71,7 @@ class FoutLayer(torch.nn.Module):
         return f"{self.__class__.__name__}({self.in_channels}, {self.out_channels})"
 
 
-class FoutNet(torch.nn.Module):  # noqa: D101
+class FoutNet(nn.Module):  # noqa: D101
     def __init__(
         self,
         input_shape,
@@ -84,14 +83,14 @@ class FoutNet(torch.nn.Module):  # noqa: D101
         self.conv1 = FoutLayer(input_shape, 16)
         self.conv2 = FoutLayer(16, 32)
 
-        self.fc1 = torch.nn.Linear(32, 64)
-        self.fc2 = torch.nn.Linear(64, output_shape)
+        self.fc1 = nn.Linear(32, 64)
+        self.fc2 = nn.Linear(64, output_shape)
 
         self.clustering = "mcl"
 
     def forward(self, data):
         act = nn.Tanhshrink()
-        act = F.relu
+        act = relu
 
         # first conv block
         data.x = act(self.conv1(data.x, data.edge_index))

--- a/deeprank2/neuralnets/gnn/ginet_nocluster.py
+++ b/deeprank2/neuralnets/gnn/ginet_nocluster.py
@@ -1,13 +1,13 @@
 import torch
-import torch.nn.functional as F
 from torch import nn
+from torch.nn.functional import dropout, leaky_relu, relu, softmax
 from torch_geometric.nn.inits import uniform
 from torch_scatter import scatter_mean, scatter_sum
 
 # ruff: noqa: ANN001, ANN201
 
 
-class GINetConvLayer(torch.nn.Module):  # noqa: D101
+class GINetConvLayer(nn.Module):  # noqa: D101
     def __init__(self, in_channels, out_channels, number_edge_features=1, bias=False):
         super().__init__()
 
@@ -37,9 +37,9 @@ class GINetConvLayer(torch.nn.Module):  # noqa: D101
         # create edge feature by concatenating node feature
         alpha = torch.cat([xrow, xcol, ed], dim=1)
         alpha = self.fc_attention(alpha)
-        alpha = F.leaky_relu(alpha)
+        alpha = leaky_relu(alpha)
 
-        alpha = F.softmax(alpha, dim=1)
+        alpha = softmax(alpha, dim=1)
         h = alpha * xcol
 
         out = torch.zeros(num_node, self.out_channels).to(alpha.device)
@@ -51,7 +51,7 @@ class GINetConvLayer(torch.nn.Module):  # noqa: D101
         return f"{self.__class__.__name__}({self.in_channels}, {self.out_channels})"
 
 
-class GINet(torch.nn.Module):  # noqa: D101
+class GINet(nn.Module):  # noqa: D101
     # input_shape -> number of node input features
     # output_shape -> number of output value per graph
     # input_shape_edge -> number of edge input features
@@ -68,7 +68,7 @@ class GINet(torch.nn.Module):  # noqa: D101
         self.dropout = 0.4
 
     def forward(self, data):
-        act = F.relu
+        act = relu
         data_ext = data.clone()
 
         # EXTERNAL INTERACTION GRAPH
@@ -91,7 +91,7 @@ class GINet(torch.nn.Module):  # noqa: D101
 
         x = torch.cat([x, x_ext], dim=1)
         x = act(self.fc1(x))
-        x = F.dropout(x, self.dropout, training=self.training)
+        x = dropout(x, self.dropout, training=self.training)
         x = self.fc2(x)
 
         return x  # noqa:RET504 (unnecessary-assign)

--- a/deeprank2/neuralnets/gnn/naive_gnn.py
+++ b/deeprank2/neuralnets/gnn/naive_gnn.py
@@ -1,20 +1,20 @@
 # Example of network that doesn't require clusters.
 
 import torch
-from torch.nn import Linear, Module, ReLU, Sequential
+from torch import nn
 from torch_scatter import scatter_mean, scatter_sum
 
 # ruff: noqa: ANN001, ANN201
 
 
-class NaiveConvolutionalLayer(Module):  # noqa: D101
+class NaiveConvolutionalLayer(nn.Module):  # noqa: D101
     def __init__(self, count_node_features, count_edge_features):
         super().__init__()
         message_size = 32
         edge_input_size = 2 * count_node_features + count_edge_features
-        self._edge_mlp = Sequential(Linear(edge_input_size, message_size), ReLU())
+        self._edge_mlp = nn.Sequential(nn.Linear(edge_input_size, message_size), nn.ReLU())
         node_input_size = count_node_features + message_size
-        self._node_mlp = Sequential(Linear(node_input_size, count_node_features), ReLU())
+        self._node_mlp = nn.Sequential(nn.Linear(node_input_size, count_node_features), nn.ReLU())
 
     def forward(self, node_features, edge_node_indices, edge_features):
         # generate messages over edges
@@ -31,7 +31,7 @@ class NaiveConvolutionalLayer(Module):  # noqa: D101
         return self._node_mlp(node_input)
 
 
-class NaiveNetwork(Module):  # noqa: D101
+class NaiveNetwork(nn.Module):  # noqa: D101
     def __init__(self, input_shape: int, output_shape: int, input_shape_edge: int):
         """NaiveNetwork.
 
@@ -44,7 +44,7 @@ class NaiveNetwork(Module):  # noqa: D101
         self._external1 = NaiveConvolutionalLayer(input_shape, input_shape_edge)
         self._external2 = NaiveConvolutionalLayer(input_shape, input_shape_edge)
         hidden_size = 128
-        self._graph_mlp = Sequential(Linear(input_shape, hidden_size), ReLU(), Linear(hidden_size, output_shape))
+        self._graph_mlp = nn.Sequential(nn.Linear(input_shape, hidden_size), nn.ReLU(), nn.Linear(hidden_size, output_shape))
 
     def forward(self, data):
         external_updated1_node_features = self._external1(data.x, data.edge_index, data.edge_attr)

--- a/deeprank2/neuralnets/gnn/sgat.py
+++ b/deeprank2/neuralnets/gnn/sgat.py
@@ -1,7 +1,6 @@
 import torch
-import torch.nn.functional as F
 from torch import nn
-from torch.nn import Parameter
+from torch.nn.functional import relu
 from torch_geometric.nn import max_pool_x
 from torch_geometric.nn.inits import uniform
 from torch_scatter import scatter_mean
@@ -11,7 +10,7 @@ from deeprank2.utils.community_pooling import community_pooling, get_preloaded_c
 # ruff: noqa: ANN001, ANN201
 
 
-class SGraphAttentionLayer(torch.nn.Module):
+class SGraphAttentionLayer(nn.Module):
     """SGraphAttentionLayer.
 
     This is a new layer that is similar to the graph attention network but simpler
@@ -40,10 +39,10 @@ class SGraphAttentionLayer(torch.nn.Module):
         self.out_channels = out_channels
         self.undirected = undirected
 
-        self.weight = Parameter(torch.Tensor(2 * in_channels, out_channels))
+        self.weight = nn.Parameter(torch.Tensor(2 * in_channels, out_channels))
 
         if bias:
-            self.bias = Parameter(torch.Tensor(out_channels))
+            self.bias = nn.Parameter(torch.Tensor(out_channels))
         else:
             self.register_parameter("bias", None)
 
@@ -88,7 +87,7 @@ class SGraphAttentionLayer(torch.nn.Module):
         return f"{self.__class__.__name__}({self.in_channels}, {self.out_channels})"
 
 
-class SGAT(torch.nn.Module):  # noqa:D101
+class SGAT(nn.Module):  # noqa:D101
     def __init__(
         self,
         input_shape,
@@ -100,14 +99,14 @@ class SGAT(torch.nn.Module):  # noqa:D101
         self.conv1 = SGraphAttentionLayer(input_shape, 16)
         self.conv2 = SGraphAttentionLayer(16, 32)
 
-        self.fc1 = torch.nn.Linear(32, 64)
-        self.fc2 = torch.nn.Linear(64, output_shape)
+        self.fc1 = nn.Linear(32, 64)
+        self.fc2 = nn.Linear(64, output_shape)
 
         self.clustering = "mcl"
 
     def forward(self, data):
         act = nn.Tanhshrink()
-        act = F.relu
+        act = relu
 
         # first conv block
         data.x = act(self.conv1(data.x, data.edge_index, data.edge_attr))

--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -30,8 +30,8 @@ class Trainer:
     """Class from which the network is trained, evaluated and tested.
 
     Args:
-        neuralnet (child class of :class:`nn.Module`, optional): Neural network class (ex. :class:`GINet`, :class:`Foutnet` etc.).
-            It should subclass :class:`nn.Module`, and it shouldn't be specific to regression or classification
+        neuralnet (child class of :class:`torch.nn.Module`, optional): Neural network class (ex. :class:`GINet`, :class:`Foutnet` etc.).
+            It should subclass :class:`torch.nn.Module`, and it shouldn't be specific to regression or classification
             in terms of output shape (:class:`Trainer` class takes care of formatting the output shape according to the task).
             More specifically, in classification task cases, softmax shouldn't be used as the last activation function.
             Defaults to None.
@@ -438,7 +438,7 @@ class Trainer:
         Args:
             lossfunction (optional): Make sure to use a loss function that is appropriate for
                 your task (classification or regression). All loss functions
-                from nn.modules.loss are listed as belonging to either
+                from torch.nn.modules.loss are listed as belonging to either
                 category (or to neither) and an exception is raised if an invalid
                 loss function is chosen for the set task.
                 Default for regression: MSELoss.

--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -30,8 +30,8 @@ class Trainer:
     """Class from which the network is trained, evaluated and tested.
 
     Args:
-        neuralnet (child class of :class:`torch.nn.Module`, optional): Neural network class (ex. :class:`GINet`, :class:`Foutnet` etc.).
-            It should subclass :class:`torch.nn.Module`, and it shouldn't be specific to regression or classification
+        neuralnet (child class of :class:`nn.Module`, optional): Neural network class (ex. :class:`GINet`, :class:`Foutnet` etc.).
+            It should subclass :class:`nn.Module`, and it shouldn't be specific to regression or classification
             in terms of output shape (:class:`Trainer` class takes care of formatting the output shape according to the task).
             More specifically, in classification task cases, softmax shouldn't be used as the last activation function.
             Defaults to None.
@@ -438,7 +438,7 @@ class Trainer:
         Args:
             lossfunction (optional): Make sure to use a loss function that is appropriate for
                 your task (classification or regression). All loss functions
-                from torch.nn.modules.loss are listed as belonging to either
+                from nn.modules.loss are listed as belonging to either
                 category (or to neither) and an exception is raised if an invalid
                 loss function is chosen for the set task.
                 Default for regression: MSELoss.

--- a/deeprank2/trainer.py
+++ b/deeprank2/trainer.py
@@ -10,8 +10,8 @@ import dill
 import h5py
 import numpy as np
 import torch
-import torch.nn.functional as F
 from torch import nn
+from torch.nn.functional import softmax
 from torch_geometric.loader import DataLoader
 from tqdm import tqdm
 
@@ -714,7 +714,7 @@ class Trainer:
             # Get the outputs for export
             # Remember that non-linear activation is automatically applied in CrossEntropyLoss
             if self.task == targets.CLASSIF:
-                pred = F.softmax(pred.detach(), dim=1)
+                pred = softmax(pred.detach(), dim=1)
             else:
                 pred = pred.detach().reshape(-1)
             outputs += pred.cpu().numpy().tolist()
@@ -784,7 +784,7 @@ class Trainer:
             # Get the outputs for export
             # Remember that non-linear activation is automatically applied in CrossEntropyLoss
             if self.task == targets.CLASSIF:
-                pred = F.softmax(pred.detach(), dim=1)
+                pred = softmax(pred.detach(), dim=1)
             else:
                 pred = pred.detach().reshape(-1)
             outputs += pred.cpu().numpy().tolist()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -10,6 +10,7 @@ import h5py
 import pandas as pd
 import pytest
 import torch
+from torch import nn
 
 from deeprank2.dataset import GraphDataset, GridDataset
 from deeprank2.domain import edgestorage as Efeat
@@ -40,7 +41,7 @@ default_features = [
 
 def _model_base_test(
     save_path: str,
-    model_class: torch.nn.Module,
+    model_class: nn.Module,
     train_hdf5_path: str,
     val_hdf5_path: str,
     test_hdf5_path: str,


### PR DESCRIPTION
- All functions from torch.nn.functional are now explicitly imported by name and used directly.
- In all other cases where classes from torch.nn are used, we do `from torch import nn` and then use `nn.<Class>` throughout.

Note that this was also changed in one docstring in fba9e56. Not sure if that messes up the rendering of the documents. That commit can easily be dropped if needed.

fix #269 