### PR TITLE
fix: dockerfile image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,35 @@
 # Pull base image
-FROM --platform=linux/x86_64 condaforge/miniforge3:23.3.1-1
+FROM --platform=linux/amd64 ubuntu:22.04
 
-# Add files
-ADD ./tutorials /home/deeprank2/tutorials
+ARG MINIFORGE_NAME=Miniforge3
+ARG MINIFORGE_VERSION=24.3.0-0
+ARG TARGETPLATFORM
+
+ENV CONDA_DIR=/opt/conda
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH=${CONDA_DIR}/bin:${PATH}
+
+RUN \
+  ## Install apt dependencies
+  apt-get update && \
+  apt-get install --no-install-recommends --yes \
+      wget bzip2 unzip ca-certificates \
+      git && \
+  ## Download and install Miniforge
+  wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/${MINIFORGE_NAME}-${MINIFORGE_VERSION}-Linux-x86_64.sh -O /tmp/miniforge.sh && \
+  /bin/bash /tmp/miniforge.sh -b -p ${CONDA_DIR} && \
+  rm /tmp/miniforge.sh && \
+  echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc && \
+  echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
+
 ADD ./env/deeprank2.yml /home/deeprank2
 
 RUN \
-  # Install dependencies and package
-  apt update -y && \
-  apt install unzip -y && \
-  ## GCC
-  apt install -y gcc && \
   ## Create the environment and install the dependencies
   mamba env create -f /home/deeprank2/deeprank2.yml && \
+  conda install -n deeprank2 conda-forge::gcc && \
   ## Activate the environment and install pip packages
-  /opt/conda/bin/conda run -n deeprank2 pip install deeprank2 && \
+  conda run -n deeprank2 pip install deeprank2 && \
   ## Activate the environment automatically when entering the container
   echo "source activate deeprank2" >~/.bashrc && \
   # Get the data for running the tutorials
@@ -22,7 +37,15 @@ RUN \
   if [ -d "/home/deeprank2/tutorials/data_processed" ]; then rm -Rf /home/deeprank2/tutorials/data_processed; fi && \
   wget https://zenodo.org/records/8349335/files/data_raw.zip && \
   unzip data_raw.zip -d data_raw && \
-  mv data_raw /home/deeprank2/tutorials
+  mv data_raw /home/deeprank2/tutorials && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  conda clean --tarballs --index-cache --packages --yes && \
+  find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
+  find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
+  conda clean --force-pkgs-dirs --all --yes
+
+ADD ./tutorials /home/deeprank2/tutorials
 
 ENV PATH /opt/conda/envs/deeprank2/bin:$PATH
 


### PR DESCRIPTION
While investigating issue #540, I encountered a problem with our Dockerfile build process. The root cause was a version mismatch with `libstdc++.so.6`, leading to the following error during a SciPy import:

```bash
libstdc++.so.6: version `GLIBCXX_3.4.29' not found
```

- The error occurred because the container was incorrectly linking to an outdated version of `libstdc++.so.6` from the system's root directory, rather than the newer version available in the Conda environment.
- Although the required GLIBCXX_3.4.29 symbol was present in the Conda-managed version of `libstdc++.so.6`, the container failed to detect it and instead used the system's older version.

To resolve this, I made the following changes:

- Updated the base image: I changed the base image from `ubuntu:20.04` to [`ubuntu:22.04`](https://hub.docker.com/layers/library/ubuntu/22.04/images/sha256-0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736?context=explore), which includes a more recent version of `libstdc++.so.6` in the system libraries.
- Manual Conda installation: instead of relying on the base image from Miniconda, I added the Conda installation steps directly in the Dockerfile taking inspiration from [the original condaforge/miniforge3 image's Dockerfile](https://github.com/conda-forge/miniforge-images/blob/master/ubuntu/Dockerfile). 

These changes allow the container to correctly locate and use the updated `libstdc++.so.6`, resolving the build issue. Next steps are outlined in #529.
